### PR TITLE
feat(android): add Android version compatibility for blur effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,26 @@ The Android implementation leverages the BlurView library to provide real blur e
 - **Fallback Handling:** Gracefully handles devices with limited graphics capabilities
 - **No Extra Permissions:** Does not require additional Android permissions
 
+### Android Version Compatibility
+
+This library automatically handles Android version compatibility to prevent `NoClassDefFoundError` issues:
+
+- **Android 12+ (API 31+):** Uses `RenderEffectBlur` for optimal performance and modern blur effects
+- **Android 10-11 (API 29-30):** Automatically falls back to `RenderScriptBlur` for compatibility
+- **Older Android versions:** Graceful fallback to semi-transparent overlay when blur is not supported
+
+**Note:** The library includes automatic API level detection and will choose the appropriate blur algorithm based on the device's Android version. This ensures compatibility across all supported Android versions without requiring any additional configuration.
+
+#### Troubleshooting Android Issues
+
+If you encounter `java.lang.NoClassDefFoundError: Failed resolution of: Landroid/graphics/RenderEffect;` on Android 10 or 11:
+
+1. **This is automatically handled** - The library now includes fallback mechanisms
+2. **Update to latest version** - Ensure you're using the latest version of this library
+3. **Clean and rebuild** - Run `cd android && ./gradlew clean` then rebuild your project
+
+The error occurs because `RenderEffect` was introduced in Android 12 (API 31), but the library now automatically detects the API level and uses compatible alternatives on older versions.
+
 ## Usage
 
 ### Basic Usage


### PR DESCRIPTION
Implement automatic fallback mechanisms for different Android versions:
- Use RenderEffectBlur for Android 12+ (API 31+)
- Fallback to RenderScriptBlur for Android 10-11 (API 29-30) and less
- Graceful fallback to semi-transparent overlay on older versions

## Summary by Sourcery

Introduce Android version compatibility for blur effects by selecting the appropriate blur algorithm at runtime and providing robust fallbacks, and update documentation accordingly

New Features:
- Automatically select blur algorithm based on Android API level: RenderEffectBlur for API 31+, RenderScriptBlur for API 29–30, and a semi-transparent overlay fallback for older or unsupported devices

Enhancements:
- Improve blur setup logic to catch initialization errors and avoid retry loops by falling back to a semi-transparent overlay
- Handle missing root views by applying the overlay instead of attempting blur setup

Documentation:
- Add Android Version Compatibility section in README with details on blur algorithm selection and troubleshooting steps