### PR TITLE
fix: blur appears only once due to didMoveToWindow default impl

### DIFF
--- a/ios/Views/AdvancedBlurView.swift
+++ b/ios/Views/AdvancedBlurView.swift
@@ -1,5 +1,3 @@
-// AdvancedBlurView.swift
-
 import SwiftUI
 import UIKit
 
@@ -67,11 +65,34 @@ import UIKit
     setupHostingController()
   }
 
-  private func setupHostingController() {
-    let blurStyle = blurStyleFromString(blurTypeString)
-    let swiftUIView = BasicColoredView(glassTintColor: glassTintColor, glassOpacity: glassOpacity, blurAmount: blurAmount, blurStyle: blurStyle, type: type, glassType: glassType, reducedTransparencyFallbackColor: reducedTransparencyFallbackColor, isInteractive: isInteractive)
-    let hosting = UIHostingController(rootView: swiftUIView)
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    if hostingController == nil {
+      setupHostingController()
+    }
+  }
 
+  private func setupHostingController() {
+    // Completely remove old hosting controller
+    if let oldHosting = hostingController {
+      oldHosting.view.removeFromSuperview()
+      oldHosting.removeFromParent()
+    }
+    hostingController = nil
+
+    let blurStyle = blurStyleFromString(blurTypeString)
+    let swiftUIView = BasicColoredView(
+      glassTintColor: glassTintColor,
+      glassOpacity: glassOpacity,
+      blurAmount: blurAmount,
+      blurStyle: blurStyle,
+      type: type,
+      glassType: glassType,
+      reducedTransparencyFallbackColor: reducedTransparencyFallbackColor,
+      isInteractive: isInteractive
+    )
+
+    let hosting = UIHostingController(rootView: swiftUIView)
     hosting.view.backgroundColor = .clear
     hosting.view.translatesAutoresizingMaskIntoConstraints = false
 
@@ -87,8 +108,28 @@ import UIKit
   }
 
   private func updateView() {
-    let blurStyle = blurStyleFromString(blurTypeString)
-    let newSwiftUIView = BasicColoredView(glassTintColor: glassTintColor, glassOpacity: glassOpacity, blurAmount: blurAmount, blurStyle: blurStyle, type:type, glassType: glassType, reducedTransparencyFallbackColor: reducedTransparencyFallbackColor, isInteractive: isInteractive)
-    hostingController?.rootView = newSwiftUIView
+    setupHostingController()
+  }
+
+  public override func didMoveToSuperview() {
+    super.didMoveToSuperview()
+    if superview != nil {
+      setupHostingController()
+    }
+  }
+  
+  public override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      setupHostingController()
+    }
+  }
+
+  deinit {
+    if let hosting = hostingController {
+      hosting.view.removeFromSuperview()
+      hosting.removeFromParent()
+    }
+    hostingController = nil
   }
 }

--- a/ios/Views/BlurEffectView.swift
+++ b/ios/Views/BlurEffectView.swift
@@ -28,8 +28,10 @@ class BlurEffectView: UIVisualEffectView {
 
   private func setupBlur() {
     // Clean up existing animator
-    animator?.stopAnimation(true)
-    animator?.finishAnimation(at: .current)
+    if let animator = animator {
+      animator.stopAnimation(true)
+      animator.finishAnimation(at: .current)
+    }
     animator = nil
 
     // Reset effect


### PR DESCRIPTION
# Pull Request

## Description
fix: blur appears only once due to didMoveToWindow default implementation on iOS devices. 

# Fixes 
https://github.com/sbaiahmed1/react-native-blur/issues/18 and probably https://github.com/sbaiahmed1/react-native-blur/issues/17

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Create a button with a state that shows the modal on click 
- Create blur background on the modal appearing
- Open modal the first time ( blur appears)
- Dismiss the modal and open it a second time (blur should now appears again)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Summary by Sourcery

Ensure the blur view reliably reappears on subsequent presentations by recreating its hosting controller whenever the view hierarchy changes and safeguard animator cleanup.

Bug Fixes:
- Fix blur appearing only once by reinitializing the UIHostingController in layoutSubviews, didMoveToSuperview, and didMoveToWindow.

Enhancements:
- Refactor setupHostingController to fully remove and replace previous hosting controllers and add deinit cleanup.
- Change updateView to rebuild the hosting controller instead of updating its rootView directly.
- Wrap animator cleanup in BlurEffectView within a safe optional binding to avoid nil-related issues.