### PR TITLE
style(ReactNativeBlurView): fix indentation and add missing closing brace

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -257,7 +257,8 @@ class ReactNativeBlurView : BlurView {
           super.setBackgroundColor(originalBackgroundColor!!)
         }
 
-        logDebug("Blur setup successful with root: ${root.javaClass.simpleName}")} catch (e: Exception) {
+        logDebug("Blur setup successful with root: ${root.javaClass.simpleName}")
+        } catch (e: Exception) {
           logWarning("Failed to setup blur algorithm: ${e.message}")
           // Fallback: use semi-transparent overlay when blur is unsupported
           super.setBackgroundColor(overlayColor)
@@ -301,6 +302,7 @@ class ReactNativeBlurView : BlurView {
           // This avoids misidentifying containers in complex layouts
           return current
         }
+      }
       current = current.parent
     }
     


### PR DESCRIPTION
closes: https://github.com/sbaiahmed1/react-native-blur/issues/25

## Summary by Sourcery

Fix indentation and missing closing brace in ReactNativeBlurView.kt to ensure the try-catch block and loop are properly closed

Bug Fixes:
- Reposition closing brace and adjust indentation for the try-catch block around logDebug
- Add missing closing brace to close the loop block correctly