### PR TITLE
build: add bigdecimal gem with version constraint

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -7,4 +7,5 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1', '!= 1.15.2'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
+gem 'bigdecimal', '!= 3.3.1'
 gem 'concurrent-ruby', '< 1.3.4'


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add bigdecimal gem to the example Gemfile with an exclusion for version 3.3.1