### PR TITLE
fix: enhance LiquidGlassView for interactive animations

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1729,7 +1729,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - ReactNativeBlur (3.2.0):
+  - ReactNativeBlur (4.0.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2108,7 +2108,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
-  ReactNativeBlur: c686e0ff7a32231489d62dea4a6097dda5f1dd9c
+  ReactNativeBlur: 9d062db757e42c26205c6d2272dd3f65d8fcbe6f
   RNScreens: f38464ec1e83bda5820c3b05ccf4908e3841c5cc
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf

--- a/ios/ReactNativeLiquidGlassView.mm
+++ b/ios/ReactNativeLiquidGlassView.mm
@@ -246,7 +246,14 @@ using namespace facebook::react;
   // Copy corner radius from the Fabric view to the inner glass view (Callstack pattern)
   _liquidGlassView.layer.cornerRadius = self.layer.cornerRadius;
   _liquidGlassView.layer.cornerCurve = self.layer.cornerCurve;
-  _liquidGlassView.layer.masksToBounds = YES;
+  
+  // On iOS 26+, don't clip bounds to allow interactive glass animations to be visible
+  // The glass effect view handles its own clipping via cornerConfiguration
+  if (@available(iOS 26.0, *)) {
+    _liquidGlassView.layer.masksToBounds = NO;
+  } else {
+    _liquidGlassView.layer.masksToBounds = YES;
+  }
 }
 
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics

--- a/ios/Views/LiquidGlassContainerView.swift
+++ b/ios/Views/LiquidGlassContainerView.swift
@@ -64,6 +64,10 @@ import UIKit
     let effectView = UIVisualEffectView()
     effectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     effectView.frame = bounds
+    
+    // Don't clip bounds to allow interactive glass animations to be visible
+    effectView.clipsToBounds = false
+    
     addSubview(effectView)
     self.glassEffectView = effectView
     
@@ -74,30 +78,6 @@ import UIKit
   
   @objc public func setBorderRadius(_ radius: CGFloat) {
     allBorderRadius = radius
-    topLeftRadius = radius
-    topRightRadius = radius
-    bottomLeftRadius = radius
-    bottomRightRadius = radius
-    updateBorderRadius()
-  }
-  
-  @objc public func setBorderTopLeftRadius(_ radius: CGFloat) {
-    topLeftRadius = radius
-    updateBorderRadius()
-  }
-  
-  @objc public func setBorderTopRightRadius(_ radius: CGFloat) {
-    topRightRadius = radius
-    updateBorderRadius()
-  }
-  
-  @objc public func setBorderBottomLeftRadius(_ radius: CGFloat) {
-    bottomLeftRadius = radius
-    updateBorderRadius()
-  }
-  
-  @objc public func setBorderBottomRightRadius(_ radius: CGFloat) {
-    bottomRightRadius = radius
     updateBorderRadius()
   }
 
@@ -129,17 +109,16 @@ import UIKit
     } else {
       backgroundColor = reducedTransparencyFallbackColor
       layer.cornerRadius = allBorderRadius
-      layer.masksToBounds = true
     }
   }
 
   private func updateBorderRadius() {
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2)
-      let topLeft = UICornerRadius(floatLiteral: Double(topLeftRadius))
-      let topRight = UICornerRadius(floatLiteral: Double(topRightRadius))
-      let bottomLeft = UICornerRadius(floatLiteral: Double(bottomLeftRadius))
-      let bottomRight = UICornerRadius(floatLiteral: Double(bottomRightRadius))
+      let topLeft = UICornerRadius(floatLiteral: Double(allBorderRadius))
+      let topRight = UICornerRadius(floatLiteral: Double(allBorderRadius))
+      let bottomLeft = UICornerRadius(floatLiteral: Double(allBorderRadius))
+      let bottomRight = UICornerRadius(floatLiteral: Double(allBorderRadius))
       
       glassEffectView?.cornerConfiguration = .corners(
         topLeftRadius: topLeft,
@@ -153,7 +132,6 @@ import UIKit
       #endif
     } else {
       layer.cornerRadius = allBorderRadius
-      layer.masksToBounds = true
     }
   }
 


### PR DESCRIPTION
resloves : https://github.com/sbaiahmed1/react-native-blur/issues/35

## Summary by Sourcery

Enable interactive liquid glass animations by disabling clipping on effect views in LiquidGlassContainerView and ReactNativeLiquidGlassView for iOS 26+, and simplify border radius handling.

Bug Fixes:
- Fix clipping behavior that prevented interactive glass animations from being visible.

Enhancements:
- Disable clipsToBounds on UIVisualEffectView in LiquidGlassContainerView to support interactive animations.
- Remove individual corner radius setters and consolidate border radius configuration into a single allBorderRadius property.
- Apply conditional layer.masksToBounds in ReactNativeLiquidGlassView based on iOS version to avoid unwanted clipping on iOS 26+.