### PR TITLE
fix(iOS): blur type unexpected behaviour during app state switch

### DIFF
--- a/ios/Views/BlurEffectView.swift
+++ b/ios/Views/BlurEffectView.swift
@@ -53,8 +53,9 @@ class BlurEffectView: UIVisualEffectView {
   }
 
   deinit {
-    animator?.stopAnimation(true)
-    animator?.finishAnimation(at: .current)
+    guard let animator = animator, animator.state == .active else { return }
+    animator.stopAnimation(true)
+    animator.finishAnimation(at: .current)
   }
 }
 


### PR DESCRIPTION
The `blurAmount` for iOS is actually the paused progress of blur effect appearing animation, which may be reset during the app goes foreground. Therefore, that animation should be marked finished instead of paused.

See
- https://stackoverflow.com/a/47475656/5466245
- https://gist.github.com/darrarski/29a2a4515508e385c90b3ffe6f975df7?permalink_comment_id=4839176#gistcomment-4839176

Related to #46

## Summary by Sourcery

Bug Fixes:
- Prevent unexpected blur intensity changes on iOS when the app returns to the foreground by stopping and finalizing the blur animation at the current state instead of pausing it.