### PR TITLE
fix(android): improve blur view layout handling in react native

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
@@ -11,6 +11,7 @@ import android.graphics.Shader
 import android.util.AttributeSet
 import android.util.Log
 import android.widget.FrameLayout
+import android.view.View.MeasureSpec
 import com.qmdeve.blurview.widget.BlurView
 import androidx.core.graphics.toColorInt
 
@@ -104,6 +105,27 @@ class ReactNativeProgressiveBlurView : FrameLayout {
     } catch (e: Exception) {
       logError("Failed to initialize progressive blur view: ${e.message}", e)
     }
+  }
+
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    val width = MeasureSpec.getSize(widthMeasureSpec)
+    val height = MeasureSpec.getSize(heightMeasureSpec)
+    setMeasuredDimension(width, height)
+
+    // Measure the internal blurView to match the parent size
+    blurView?.measure(
+      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+    )
+  }
+
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    // Layout the internal blurView to fill the parent
+    val width = right - left
+    val height = bottom - top
+    blurView?.layout(0, 0, width, height)
+
+    // Do NOT call super.onLayout to avoid interfering with React Native children
   }
 
   override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
- Implement proper measure and layout methods to prevent layout conflicts with Yoga.
- Add missing layout params  and measurement logic to ensure views respects parent.

resloves: https://github.com/sbaiahmed1/react-native-blur/issues/57

## Summary by Sourcery

Improve Android blur view components’ integration with React Native’s layout system to avoid conflicts with Yoga and ensure correct sizing.

Bug Fixes:
- Prevent BlurViewGroup from overriding React Native’s layout by supplying appropriate layout params and a no-op onLayout implementation.
- Ensure the progressive blur view and its internal blur view are measured and laid out to consistently match their parent size in React Native layouts.

Enhancements:
- Set a default downsample factor for the main blur view to improve visual quality and consistency across usages.