### PR TITLE
fix: resolve Kotlin 2.0 build failure on Android

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -88,7 +88,7 @@ class ReactNativeBlurView : BlurViewGroup {
       super.setOverlayColor(currentOverlayColor)
       super.setDownsampleFactor(6.0F)
 
-      super.clipChildren = true
+      clipChildren = true
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         super.setBackgroundColor(currentOverlayColor)
@@ -287,14 +287,14 @@ class ReactNativeBlurView : BlurViewGroup {
       )
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        super.rootView.outlineProvider = object : ViewOutlineProvider() {
+        rootView.outlineProvider = object : ViewOutlineProvider() {
           @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
           override fun getOutline(view: View, outline: Outline?) {
             outline?.setRoundRect(0, 0, view.width, view.height, radiusInPixels)
           }
         }
 
-        super.clipToOutline = true
+        clipToOutline = true
       }
 
       super.setCornerRadius(radiusInPixels)


### PR DESCRIPTION
Kotlin 2.0 introduced stricter rules around super usage. Property setters in Kotlin are implemented as extension functions, and super cannot be used as a receiver for extension functions in Kotlin 2.0+.
✅ Kotlin 1.x
✅ Kotlin 2.0+

Problem
Android build fails with the following errors:
e: ReactNativeBlurView.kt:91:7 'super' is not an expression, it can not be used as a receiver for extension functions
e: ReactNativeBlurView.kt:290:9 'super' is not an expression, it can not be used as a receiver for extension functions
e: ReactNativeBlurView.kt:297:9 'super' is not an expression, it can not be used as a receiver for extension functions
react-native: 0.76.6
expo: 52.0.44
Android Gradle Plugin: 8.9.1
Gradle: 8.11.1
compileSdkVersion: 36
targetSdkVersion: 35
minSdkVersion: 24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal property references for improved code clarity with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->