### PR TITLE
feat: add web platform support using CSS backdrop-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @sbaiahmed1/react-native-blur
 
-A modern React Native library providing **six specialized components** for advanced visual effects: `BlurView` for native blur effects, `VibrancyView` for iOS vibrancy effects, `LiquidGlassView` for cutting-edge liquid glass effects on iOS 26+ (with Android fallback to enhanced blur), `LiquidGlassContainer` for iOS 26+ glass container effects with configurable spacing, `ProgressiveBlurView` for smooth, variable blur transitions, and `BlurSwitch` for beautiful blur switch buttons on Android.
+A modern React Native library providing six specialized components for advanced visual effects across iOS, Android, and Web: BlurView for native blur effects, VibrancyView for iOS vibrancy effects, LiquidGlassView for cutting-edge liquid glass effects on iOS 26+ (with Android fallback to enhanced blur), LiquidGlassContainer for iOS 26+ glass container effects with configurable spacing, ProgressiveBlurView for smooth, variable blur transitions, and BlurSwitch for beautiful blur switch buttons on Android.
 
 > **⚠️ Breaking Changes**: If upgrading from 3.x, see [Breaking Changes](#️-breaking-changes-in-v400) section.
 
@@ -60,6 +60,8 @@ A modern React Native library providing **six specialized components** for advan
 | **React Native**          | 0.68+ (New Architecture)                              |
 | **Android**               | API 24+ (Android 7.0)                                 |
 | **Android Gradle Plugin** | 8.9.1+                                                |
+| **Web**                   | Chrome 76+, Edge 79+, Firefox 103+ and Safari 9+      |
+| **Web Backdrop Filter**   | ~96% global support                                   |
 
 > ⚠️ **Note**: LiquidGlassView requires Xcode 26.0+ and iOS 26+ for full glass effects. The component automatically falls back to enhanced blur on older versions.
 
@@ -158,8 +160,9 @@ import { LiquidGlassView } from '@sbaiahmed1/react-native-blur';
   - `LiquidGlassContainer` - iOS 26+ glass container with configurable spacing for grouping glass elements
   - `BlurSwitch` - Beautiful blur switch button using QmBlurView (Android)
 - �🌊 **Liquid Glass Effects**: Revolutionary glass effects using iOS 26+ UIGlassEffect API
-- 🎨 **Multiple Blur Types**: Support for various blur styles including system materials on iOS
+- 🎨 **Multiple Blur Types**: Support for various blur styles, including system materials on iOS
 - 📱 **Cross-Platform**: Works on both iOS and Android
+- 🖥️ **Web Support**: Works on Web applications
 - ♿ **Accessibility**: Automatic fallback for reduced transparency settings
 - 🔧 **TypeScript**: Full TypeScript support with proper type definitions for all components
 - 🚀 **Turbo Module**: Built with React Native's new architecture (Fabric)
@@ -658,7 +661,7 @@ All props are optional and have sensible defaults.
 > **Platform Note**: `ProgressiveBlurView` works on both **iOS** and **Android**.
 >
 > - **iOS**: Uses private Core Animation filters for variable blur effects
-> - **Android**: Extends QMBlur's BlurView with custom gradient masking to create progressive blur effect
+> - **Android**: Extends QMBlur's BlurView with custom gradient masking to create a progressive blur effect
 
 ### LiquidGlassView Props
 
@@ -789,6 +792,20 @@ All components automatically respect the "Reduce Transparency" accessibility set
 - **iOS < 26 & Android**: Always renders as regular View
 
 You can customize the fallback color using the `reducedTransparencyFallbackColor` prop on `BlurView` and `LiquidGlassView` components.
+
+### Web
+
+All components are supported on web via platform-specific `.web.tsx` files that Metro/webpack automatically resolves when bundling for React Native Web. No additional configuration is required.
+
+#### Browser support
+
+CSS `backdrop-filter` is supported in all modern browsers (~96% global support):
+
+- **Chrome** 76+, **Edge** 79+, **Firefox** 103+, **Safari** 9+ (with `-webkit-` prefix)
+
+#### BlurType mapping
+
+All 21 `BlurType` values are mapped to appropriate `rgba()` background colors that approximate native iOS `UIVisualEffectView` tints — light variants map to white-based overlays and dark variants to black-based overlays with graduated opacity.
 
 ## TypeScript Support
 

--- a/src/BlurSwitch.tsx
+++ b/src/BlurSwitch.tsx
@@ -29,7 +29,8 @@ export interface BlurSwitchProps {
   /**
    * @description The intensity of the blur effect (0-100)
    *
-   * @platform android
+   * @platform Android
+   *
    * @default 10
    */
   blurAmount?: number;

--- a/src/BlurSwitch.web.tsx
+++ b/src/BlurSwitch.web.tsx
@@ -3,15 +3,64 @@ import { Switch } from 'react-native';
 import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
 
 export interface BlurSwitchProps {
+  /**
+   * @description The current value of the switch
+   *
+   * @default false
+   */
   value?: boolean;
+
+  /**
+   * @description Callback invoked when the switch value changes
+   *
+   * @default undefined
+   */
   onValueChange?: (value: boolean) => void;
+
+  /**
+   * @description The intensity of the blur effect (0-100)
+   *
+   * @platform Android
+   *
+   * @default 10
+   */
   blurAmount?: number;
+
+  /**
+   * @description The color of the switch thumb
+   *
+   * @platform ios
+   *
+   * @default '#FFFFFF'
+   */
   thumbColor?: ColorValue;
+
+  /**
+   * @description The track colors for off and on states
+   *
+   * Note: On Android, you only need to set the `true` (base) color.
+   * QmBlurView will automatically calculate the on/off state colors.
+   * The `false` color is only used on iOS.
+   *
+   * @default { false: '#E5E5EA', true: '#34C759' }
+   */
   trackColor?: {
     false?: ColorValue;
     true?: ColorValue;
   };
+
+  /**
+   * @description Whether the switch is disabled
+   *
+   * @default false
+   */
   disabled?: boolean;
+
+  /**
+   * @description Style object for the switch view
+   *
+   * @default undefined
+   */
   style?: StyleProp<ViewStyle>;
 }
 
@@ -21,6 +70,16 @@ export interface BlurSwitchProps {
  * The native Android version renders a blur-styled switch via QmBlurView.
  * On web we fall back to React Native's built-in Switch component, which
  * renders a standard checkbox toggle.
+ *
+ * @example
+ * ```tsx
+ * <BlurSwitch
+ *   value={isEnabled}
+ *   onValueChange={setIsEnabled}
+ *   blurAmount={20}
+ *   trackColor={{ true: '#34C759' }}
+ * />
+ * ```
  */
 export const BlurSwitch: React.FC<BlurSwitchProps> = ({
   value = false,

--- a/src/BlurSwitch.web.tsx
+++ b/src/BlurSwitch.web.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch } from 'react-native';
+import { StyleSheet, Switch } from 'react-native';
 import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
 
 export interface BlurSwitchProps {
@@ -99,10 +99,16 @@ export const BlurSwitch: React.FC<BlurSwitchProps> = ({
       thumbColor={thumbColor}
       trackColor={trackColor}
       disabled={disabled}
-      style={style}
+      style={[styles.container, style]}
       {...props}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    zIndex: 1,
+  },
+});
 
 export default BlurSwitch;

--- a/src/BlurSwitch.web.tsx
+++ b/src/BlurSwitch.web.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Switch } from 'react-native';
+import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
+
+export interface BlurSwitchProps {
+  value?: boolean;
+  onValueChange?: (value: boolean) => void;
+  blurAmount?: number;
+  thumbColor?: ColorValue;
+  trackColor?: {
+    false?: ColorValue;
+    true?: ColorValue;
+  };
+  disabled?: boolean;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Web implementation of BlurSwitch.
+ *
+ * The native Android version renders a blur-styled switch via QmBlurView.
+ * On web we fall back to React Native's built-in Switch component, which
+ * renders a standard checkbox toggle.
+ */
+export const BlurSwitch: React.FC<BlurSwitchProps> = ({
+  value = false,
+  onValueChange,
+  thumbColor = '#FFFFFF',
+  trackColor = { false: '#E5E5EA', true: '#34C759' },
+  disabled = false,
+  style,
+  // Accepted for API compat, unused on web
+  blurAmount: _blurAmount,
+  ...props
+}) => {
+  return (
+    <Switch
+      value={value}
+      onValueChange={onValueChange}
+      thumbColor={thumbColor}
+      trackColor={trackColor}
+      disabled={disabled}
+      style={style}
+      {...props}
+    />
+  );
+};
+
+export default BlurSwitch;

--- a/src/BlurView.web.tsx
+++ b/src/BlurView.web.tsx
@@ -137,6 +137,7 @@ export const BlurView: React.FC<BlurViewProps> = ({
   const overlay = overlayColor ? { backgroundColor: overlayColor } : undefined;
 
   const blurStyle: Record<string, unknown> = {
+    zIndex: 1,
     backgroundColor: tint,
     backdropFilter: `blur(${blurPx}px)`,
     WebkitBackdropFilter: `blur(${blurPx}px)`,

--- a/src/BlurView.web.tsx
+++ b/src/BlurView.web.tsx
@@ -1,0 +1,118 @@
+import React, { Children } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
+import type { BlurType } from './ReactNativeBlurViewNativeComponent';
+
+export interface BlurViewProps {
+  blurType?: BlurType;
+  blurAmount?: number;
+  reducedTransparencyFallbackColor?: string;
+  overlayColor?: ColorValue;
+  style?: StyleProp<ViewStyle>;
+  ignoreSafeArea?: boolean;
+  children?: React.ReactNode;
+}
+
+/**
+ * Maps native blur types to semi-transparent CSS background colours.
+ *
+ * The colours approximate the visual tint each blur type produces on iOS:
+ * - Light variants use white-based overlays
+ * - Dark variants use black-based overlays
+ * - Material variants match the iOS system material hierarchy
+ */
+const blurTypeToBackground: Record<BlurType, string> = {
+  // Base types
+  xlight: 'rgba(255, 255, 255, 0.6)',
+  light: 'rgba(255, 255, 255, 0.4)',
+  dark: 'rgba(0, 0, 0, 0.5)',
+  extraDark: 'rgba(0, 0, 0, 0.75)',
+  regular: 'rgba(255, 255, 255, 0.2)',
+  prominent: 'rgba(255, 255, 255, 0.35)',
+
+  // System materials (default / adaptive)
+  systemUltraThinMaterial: 'rgba(255, 255, 255, 0.1)',
+  systemThinMaterial: 'rgba(255, 255, 255, 0.2)',
+  systemMaterial: 'rgba(255, 255, 255, 0.3)',
+  systemThickMaterial: 'rgba(255, 255, 255, 0.45)',
+  systemChromeMaterial: 'rgba(255, 255, 255, 0.5)',
+
+  // System materials (light)
+  systemUltraThinMaterialLight: 'rgba(255, 255, 255, 0.15)',
+  systemThinMaterialLight: 'rgba(255, 255, 255, 0.25)',
+  systemMaterialLight: 'rgba(255, 255, 255, 0.4)',
+  systemThickMaterialLight: 'rgba(255, 255, 255, 0.55)',
+  systemChromeMaterialLight: 'rgba(255, 255, 255, 0.6)',
+
+  // System materials (dark)
+  systemUltraThinMaterialDark: 'rgba(0, 0, 0, 0.2)',
+  systemThinMaterialDark: 'rgba(0, 0, 0, 0.3)',
+  systemMaterialDark: 'rgba(0, 0, 0, 0.45)',
+  systemThickMaterialDark: 'rgba(0, 0, 0, 0.6)',
+  systemChromeMaterialDark: 'rgba(0, 0, 0, 0.7)',
+};
+
+/**
+ * Web implementation of BlurView using CSS `backdrop-filter`.
+ *
+ * Renders a `<View>` with `backdrop-filter: blur(Npx)` and a semi-transparent
+ * background tint derived from `blurType`. This closely approximates the native
+ * iOS UIVisualEffectView and Android QmBlurView behaviour in modern browsers.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
+ */
+export const BlurView: React.FC<BlurViewProps> = ({
+  blurType = 'xlight',
+  blurAmount = 10,
+  overlayColor,
+  style,
+  children,
+  // Accepted for API compat, unused on web
+  reducedTransparencyFallbackColor: _fallback,
+  ignoreSafeArea: _ignoreSafeArea,
+  ...props
+}) => {
+  const blurPx = Math.min(Math.max(blurAmount, 0), 100);
+  const tint = blurTypeToBackground[blurType] ?? blurTypeToBackground.xlight;
+  const overlay = overlayColor ? { backgroundColor: overlayColor } : undefined;
+
+  const blurStyle = {
+    backgroundColor: tint,
+    backdropFilter: `blur(${blurPx}px)`,
+    WebkitBackdropFilter: `blur(${blurPx}px)`,
+  };
+
+  if (!Children.count(children)) {
+    return (
+      <View
+        style={[style, overlay, blurStyle as Record<string, unknown>]}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <View style={[styles.container, style, overlay]} {...props}>
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          blurStyle as Record<string, unknown>,
+        ]}
+      />
+      <View style={styles.children}>{children}</View>
+    </View>
+  );
+};
+
+export default BlurView;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  children: {
+    position: 'relative',
+    zIndex: 1,
+  },
+});

--- a/src/BlurView.web.tsx
+++ b/src/BlurView.web.tsx
@@ -4,24 +4,71 @@ import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
 import type { BlurType } from './ReactNativeBlurViewNativeComponent';
 
 export interface BlurViewProps {
+  /**
+   * @description The type of blur effect to apply
+   *
+   * @default 'xlight'
+   */
   blurType?: BlurType;
+
+  /**
+   * @description The intensity of the blur effect (0-100)
+   *
+   * @default 10
+   */
   blurAmount?: number;
+
+  /**
+   * @description Fallback color when reduced transparency is enabled
+   *
+   * Accepts hex color strings like `#FFFFFF`
+   *
+   * @platform ios & Android
+   *
+   * @default '#FFFFFF'
+   */
   reducedTransparencyFallbackColor?: string;
+
+  /**
+   * @description The overlay color to apply on top of the blur effect
+   *
+   * @default undefined
+   */
   overlayColor?: ColorValue;
+
+  /**
+   * @description style object for the blur view
+   *
+   * @default undefined
+   */
   style?: StyleProp<ViewStyle>;
+
+  /**
+   * @description style object for the blur view
+   *
+   * @platform ios & Android
+   *
+   * @default false
+   */
   ignoreSafeArea?: boolean;
+
+  /**
+   * @description Child components to render inside the blur view
+   *
+   * @default undefined
+   */
   children?: React.ReactNode;
 }
 
 /**
- * Maps native blur types to semi-transparent CSS background colours.
+ * Maps native blur types to semi-transparent CSS background colors.
  *
- * The colours approximate the visual tint each blur type produces on iOS:
+ * The colors approximate the visual tint each blur type produces on iOS:
  * - Light variants use white-based overlays
  * - Dark variants use black-based overlays
  * - Material variants match the iOS system material hierarchy
  */
-const blurTypeToBackground: Record<BlurType, string> = {
+const BLUR_TYPE_TO_BACKGROUND: Record<BlurType, string> = {
   // Base types
   xlight: 'rgba(255, 255, 255, 0.6)',
   light: 'rgba(255, 255, 255, 0.4)',
@@ -60,6 +107,18 @@ const blurTypeToBackground: Record<BlurType, string> = {
  * iOS UIVisualEffectView and Android QmBlurView behaviour in modern browsers.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
+ *
+ * @example
+ * ```tsx
+ * <BlurView
+ *   blurType="light"
+ *   blurAmount={20}
+ *   style={{ flex: 1 }}
+ * >
+ *   <Text>Content on top of blur</Text>
+ *   <Button title="Interactive Button" onPress={() => {}} />
+ * </BlurView>
+ * ```
  */
 export const BlurView: React.FC<BlurViewProps> = ({
   blurType = 'xlight',
@@ -73,32 +132,23 @@ export const BlurView: React.FC<BlurViewProps> = ({
   ...props
 }) => {
   const blurPx = Math.min(Math.max(blurAmount, 0), 100);
-  const tint = blurTypeToBackground[blurType] ?? blurTypeToBackground.xlight;
+  const tint =
+    BLUR_TYPE_TO_BACKGROUND[blurType] ?? BLUR_TYPE_TO_BACKGROUND.xlight;
   const overlay = overlayColor ? { backgroundColor: overlayColor } : undefined;
 
-  const blurStyle = {
+  const blurStyle: Record<string, unknown> = {
     backgroundColor: tint,
     backdropFilter: `blur(${blurPx}px)`,
     WebkitBackdropFilter: `blur(${blurPx}px)`,
   };
 
   if (!Children.count(children)) {
-    return (
-      <View
-        style={[style, overlay, blurStyle as Record<string, unknown>]}
-        {...props}
-      />
-    );
+    return <View style={[style, overlay, blurStyle]} {...props} />;
   }
 
   return (
     <View style={[styles.container, style, overlay]} {...props}>
-      <View
-        style={[
-          StyleSheet.absoluteFill,
-          blurStyle as Record<string, unknown>,
-        ]}
-      />
+      <View style={[StyleSheet.absoluteFill, blurStyle]} />
       <View style={styles.children}>{children}</View>
     </View>
   );

--- a/src/LiquidGlassContainer.tsx
+++ b/src/LiquidGlassContainer.tsx
@@ -7,6 +7,8 @@ export interface LiquidGlassContainerProps extends ViewProps {
    * The spacing value for the glass container effect
    * Platform: iOS only (iOS 26+)
    *
+   * @platform ios
+   *
    * @default 0
    */
   spacing?: number;

--- a/src/LiquidGlassContainer.web.tsx
+++ b/src/LiquidGlassContainer.web.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import type { ViewProps } from 'react-native';
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 export interface LiquidGlassContainerProps extends ViewProps {
   /**
@@ -36,8 +36,13 @@ export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
   children,
   ...rest
 }) => {
+  const containerStyle: StyleProp<ViewStyle> = {
+    zIndex: 1,
+    gap: spacing,
+  };
+
   return (
-    <View style={[{ gap: spacing }, style]} {...rest}>
+    <View style={[containerStyle, style]} {...rest}>
       {children}
     </View>
   );

--- a/src/LiquidGlassContainer.web.tsx
+++ b/src/LiquidGlassContainer.web.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+export interface LiquidGlassContainerProps extends ViewProps {
+  spacing?: number;
+}
+
+/**
+ * Web implementation of LiquidGlassContainer.
+ *
+ * The native iOS 26+ component groups glass views with a shared effect.
+ * On web there is no equivalent API, so this renders a plain View that
+ * maps the `spacing` prop to CSS `gap` for flex-based layout.
+ */
+export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
+  spacing = 0,
+  style,
+  children,
+  ...rest
+}) => {
+  return (
+    <View
+      style={[{ gap: spacing } as Record<string, unknown>, style]}
+      {...rest}
+    >
+      {children}
+    </View>
+  );
+};

--- a/src/LiquidGlassContainer.web.tsx
+++ b/src/LiquidGlassContainer.web.tsx
@@ -3,6 +3,14 @@ import { View } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 export interface LiquidGlassContainerProps extends ViewProps {
+  /**
+   * The spacing value for the glass container effect
+   * Platform: iOS only (iOS 26+)
+   *
+   * @platform ios
+   *
+   * @default 0
+   */
   spacing?: number;
 }
 
@@ -12,6 +20,15 @@ export interface LiquidGlassContainerProps extends ViewProps {
  * The native iOS 26+ component groups glass views with a shared effect.
  * On web there is no equivalent API, so this renders a plain View that
  * maps the `spacing` prop to CSS `gap` for flex-based layout.
+ *
+ * @platform ios
+ *
+ * @example
+ * ```tsx
+ * <LiquidGlassContainer spacing={20} style={{ flex: 1 }}>
+ *   <Text>Content inside glass container</Text>
+ * </LiquidGlassContainer>
+ * ```
  */
 export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
   spacing = 0,
@@ -20,10 +37,7 @@ export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
   ...rest
 }) => {
   return (
-    <View
-      style={[{ gap: spacing } as Record<string, unknown>, style]}
-      {...rest}
-    >
+    <View style={[{ gap: spacing }, style]} {...rest}>
       {children}
     </View>
   );

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -11,6 +11,8 @@ export interface LiquidGlassViewProps {
    * The type of glass effect to apply
    * Platform: iOS 26+ only
    *
+   * @platform ios
+   *
    * @default 'clear'
    */
   glassType?: GlassType;
@@ -20,6 +22,8 @@ export interface LiquidGlassViewProps {
    * Accepts hex color strings like '#FFFFFF' or color names
    * Platform: iOS 26+ only
    *
+   * @platform ios
+   *
    * @default 'clear'
    */
   glassTintColor?: string;
@@ -27,6 +31,8 @@ export interface LiquidGlassViewProps {
   /**
    * The opacity of the glass effect (0-1)
    * Platform: iOS 26+ only
+   *
+   * @platform ios
    *
    * @default 1.0
    */
@@ -37,6 +43,8 @@ export interface LiquidGlassViewProps {
    * Accepts hex color strings like '#FFFFFF'
    * Platform: iOS only
    *
+   * @platform ios
+   *
    * @default '#FFFFFF'
    */
   reducedTransparencyFallbackColor?: string;
@@ -44,6 +52,8 @@ export interface LiquidGlassViewProps {
   /**
    * Whether the glass view should be interactive
    * Platform: iOS 26+ only
+   *
+   * @platform ios
    *
    * @default true
    */
@@ -53,17 +63,23 @@ export interface LiquidGlassViewProps {
    * Whether the glass view should ignore safe area insets
    * Platform: iOS 26+ only
    *
+   * @platform ios
+   *
    * @default false
    */
   ignoreSafeArea?: boolean;
 
   /**
    * Style object for the liquid glass view
+   *
+   * @default undefined
    */
   style?: StyleProp<ViewStyle>;
 
   /**
    * Child components to render inside the liquid glass view
+   *
+   * @default undefined
    */
   children?: React.ReactNode;
 }
@@ -83,6 +99,8 @@ export interface LiquidGlassViewProps {
  * effect is positioned absolutely behind the content, ensuring interactive elements
  * work correctly.
  *
+ * @platform ios
+ *
  * @example
  * ```tsx
  * import { LiquidGlassView } from '@sbaiahmed1/react-native-blur';
@@ -97,8 +115,6 @@ export interface LiquidGlassViewProps {
  *   <Button title="Interactive Button" onPress={() => {}} />
  * </LiquidGlassView>
  * ```
- *
- * @platform ios
  */
 export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
   glassType = 'clear',

--- a/src/LiquidGlassView.web.tsx
+++ b/src/LiquidGlassView.web.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { ViewStyle, StyleProp } from 'react-native';
+import type { GlassType } from './ReactNativeLiquidGlassViewNativeComponent';
+
+export interface LiquidGlassViewProps {
+  glassType?: GlassType;
+  glassTintColor?: string;
+  glassOpacity?: number;
+  reducedTransparencyFallbackColor?: string;
+  isInteractive?: boolean;
+  ignoreSafeArea?: boolean;
+  style?: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+}
+
+/**
+ * Web implementation of LiquidGlassView.
+ *
+ * iOS 26+ uses UIGlassContainerEffect for a translucent glass look.
+ * On web we approximate this with `backdrop-filter: blur() saturate()`
+ * plus a semi-transparent tint colour overlay, producing a glass-like panel.
+ */
+export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
+  glassTintColor = 'clear',
+  glassOpacity = 1.0,
+  style,
+  children,
+  // Accepted for API compat, unused on web
+  glassType: _glassType,
+  reducedTransparencyFallbackColor: _fallback,
+  isInteractive: _isInteractive,
+  ignoreSafeArea: _ignoreSafeArea,
+  ...props
+}) => {
+  const tintColor =
+    glassTintColor === 'clear'
+      ? `rgba(255, 255, 255, ${0.15 * glassOpacity})`
+      : glassTintColor;
+
+  const glassStyle = {
+    backgroundColor: tintColor,
+    backdropFilter: 'blur(40px) saturate(180%)',
+    WebkitBackdropFilter: 'blur(40px) saturate(180%)',
+    opacity: glassOpacity,
+  };
+
+  return (
+    <View style={[styles.container, style]} {...props}>
+      <View
+        style={[StyleSheet.absoluteFill, glassStyle as Record<string, unknown>]}
+      />
+      <View style={styles.children}>{children}</View>
+    </View>
+  );
+};
+
+export default LiquidGlassView;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  children: {
+    position: 'relative',
+    zIndex: 1,
+  },
+});

--- a/src/LiquidGlassView.web.tsx
+++ b/src/LiquidGlassView.web.tsx
@@ -123,6 +123,7 @@ export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
       : glassTintColor;
 
   const glassStyle: Record<string, unknown> = {
+    zIndex: 1,
     backgroundColor: tintColor,
     backdropFilter: 'blur(40px) saturate(180%)',
     WebkitBackdropFilter: 'blur(40px) saturate(180%)',

--- a/src/LiquidGlassView.web.tsx
+++ b/src/LiquidGlassView.web.tsx
@@ -4,13 +4,80 @@ import type { ViewStyle, StyleProp } from 'react-native';
 import type { GlassType } from './ReactNativeLiquidGlassViewNativeComponent';
 
 export interface LiquidGlassViewProps {
+  /**
+   * The type of glass effect to apply
+   * Platform: iOS 26+ only
+   *
+   * @platform ios
+   *
+   * @default 'clear'
+   */
   glassType?: GlassType;
+
+  /**
+   * The tint color of the glass effect
+   * Accepts hex color strings like '#FFFFFF' or color names
+   * Platform: iOS 26+ only
+   *
+   * @platform ios
+   *
+   * @default 'clear'
+   */
   glassTintColor?: string;
+
+  /**
+   * The opacity of the glass effect (0-1)
+   * Platform: iOS 26+ only
+   *
+   * @platform ios
+   *
+   * @default 1.0
+   */
   glassOpacity?: number;
+
+  /**
+   * Fallback color when reduced transparency is enabled or on older iOS versions
+   * Accepts hex color strings like '#FFFFFF'
+   * Platform: iOS only
+   *
+   * @platform ios
+   *
+   * @default '#FFFFFF'
+   */
   reducedTransparencyFallbackColor?: string;
+
+  /**
+   * Whether the glass view should be interactive
+   * Platform: iOS 26+ only
+   *
+   * @platform ios
+   *
+   * @default true
+   */
   isInteractive?: boolean;
+
+  /**
+   * Whether the glass view should ignore safe area insets
+   * Platform: iOS 26+ only
+   *
+   * @platform ios
+   *
+   * @default false
+   */
   ignoreSafeArea?: boolean;
+
+  /**
+   * Style object for the liquid glass view
+   *
+   * @default undefined
+   */
   style?: StyleProp<ViewStyle>;
+
+  /**
+   * Child components to render inside the liquid glass view
+   *
+   * @default undefined
+   */
   children?: React.ReactNode;
 }
 
@@ -20,6 +87,23 @@ export interface LiquidGlassViewProps {
  * iOS 26+ uses UIGlassContainerEffect for a translucent glass look.
  * On web we approximate this with `backdrop-filter: blur() saturate()`
  * plus a semi-transparent tint colour overlay, producing a glass-like panel.
+ *
+ * @example
+ * ```tsx
+ * import { LiquidGlassView } from '@sbaiahmed1/react-native-blur';
+ *
+ * <LiquidGlassView
+ *   glassType="clear"
+ *   glassTintColor="#007AFF"
+ *   glassOpacity={0.8}
+ *   style={{ flex: 1 }}
+ * >
+ *   <Text>Content on top of liquid glass</Text>
+ *   <Button title="Interactive Button" onPress={() => {}} />
+ * </LiquidGlassView>
+ * ```
+ *
+ * @platform ios
  */
 export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
   glassTintColor = 'clear',
@@ -38,7 +122,7 @@ export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
       ? `rgba(255, 255, 255, ${0.15 * glassOpacity})`
       : glassTintColor;
 
-  const glassStyle = {
+  const glassStyle: Record<string, unknown> = {
     backgroundColor: tintColor,
     backdropFilter: 'blur(40px) saturate(180%)',
     WebkitBackdropFilter: 'blur(40px) saturate(180%)',
@@ -47,9 +131,7 @@ export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
 
   return (
     <View style={[styles.container, style]} {...props}>
-      <View
-        style={[StyleSheet.absoluteFill, glassStyle as Record<string, unknown>]}
-      />
+      <View style={[StyleSheet.absoluteFill, glassStyle]} />
       <View style={styles.children}>{children}</View>
     </View>
   );

--- a/src/ProgressiveBlurView.tsx
+++ b/src/ProgressiveBlurView.tsx
@@ -46,6 +46,8 @@ export interface ProgressiveBlurViewProps {
    *
    * Accepts hex color strings like `#FFFFFF`
    *
+   * @platform ios
+   *
    * @default '#FFFFFF'
    */
   reducedTransparencyFallbackColor?: string;

--- a/src/ProgressiveBlurView.web.tsx
+++ b/src/ProgressiveBlurView.web.tsx
@@ -1,0 +1,131 @@
+import React, { Children } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
+import type { BlurType } from './ReactNativeBlurViewNativeComponent';
+import type { ProgressiveBlurDirection } from './ReactNativeProgressiveBlurViewNativeComponent';
+
+export interface ProgressiveBlurViewProps {
+  blurType?: BlurType;
+  blurAmount?: number;
+  direction?: ProgressiveBlurDirection;
+  startOffset?: number;
+  reducedTransparencyFallbackColor?: string;
+  overlayColor?: ColorValue;
+  style?: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+}
+
+/**
+ * Maps native blur types to semi-transparent CSS background colours.
+ */
+const blurTypeToBackground: Record<BlurType, string> = {
+  xlight: 'rgba(255, 255, 255, 0.6)',
+  light: 'rgba(255, 255, 255, 0.4)',
+  dark: 'rgba(0, 0, 0, 0.5)',
+  extraDark: 'rgba(0, 0, 0, 0.75)',
+  regular: 'rgba(255, 255, 255, 0.2)',
+  prominent: 'rgba(255, 255, 255, 0.35)',
+  systemUltraThinMaterial: 'rgba(255, 255, 255, 0.1)',
+  systemThinMaterial: 'rgba(255, 255, 255, 0.2)',
+  systemMaterial: 'rgba(255, 255, 255, 0.3)',
+  systemThickMaterial: 'rgba(255, 255, 255, 0.45)',
+  systemChromeMaterial: 'rgba(255, 255, 255, 0.5)',
+  systemUltraThinMaterialLight: 'rgba(255, 255, 255, 0.15)',
+  systemThinMaterialLight: 'rgba(255, 255, 255, 0.25)',
+  systemMaterialLight: 'rgba(255, 255, 255, 0.4)',
+  systemThickMaterialLight: 'rgba(255, 255, 255, 0.55)',
+  systemChromeMaterialLight: 'rgba(255, 255, 255, 0.6)',
+  systemUltraThinMaterialDark: 'rgba(0, 0, 0, 0.2)',
+  systemThinMaterialDark: 'rgba(0, 0, 0, 0.3)',
+  systemMaterialDark: 'rgba(0, 0, 0, 0.45)',
+  systemThickMaterialDark: 'rgba(0, 0, 0, 0.6)',
+  systemChromeMaterialDark: 'rgba(0, 0, 0, 0.7)',
+};
+
+/**
+ * Returns a CSS mask-image gradient string for the given progressive blur
+ * direction. The opaque part of the mask reveals the full blur; transparent
+ * areas show no blur.
+ */
+const getMaskGradient = (
+  direction: ProgressiveBlurDirection,
+  startOffset: number
+): string => {
+  const start = `${Math.round(startOffset * 100)}%`;
+  const end = `${100 - Math.round(startOffset * 100)}%`;
+
+  switch (direction) {
+    case 'blurredTopClearBottom':
+      return `linear-gradient(to bottom, black ${start}, transparent 100%)`;
+    case 'blurredBottomClearTop':
+      return `linear-gradient(to top, black ${start}, transparent 100%)`;
+    case 'blurredCenterClearTopAndBottom':
+      return `linear-gradient(to bottom, transparent 0%, black ${start}, black ${end}, transparent 100%)`;
+  }
+};
+
+/**
+ * Web implementation of ProgressiveBlurView using CSS `backdrop-filter`
+ * combined with CSS `mask-image` to create a gradient blur effect.
+ *
+ * The mask controls where the blur is visible:
+ * - Opaque areas of the mask reveal the full blur
+ * - Transparent areas show no blur
+ *
+ * This approximates the native iOS/Android gradient blur behaviour.
+ */
+export const ProgressiveBlurView: React.FC<ProgressiveBlurViewProps> = ({
+  blurType = 'regular',
+  blurAmount = 20,
+  direction = 'blurredTopClearBottom',
+  startOffset = 0.0,
+  overlayColor,
+  style,
+  children,
+  // Accepted for API compat, unused on web
+  reducedTransparencyFallbackColor: _fallback,
+  ...props
+}) => {
+  const blurPx = Math.min(Math.max(blurAmount, 0), 100);
+  const tint = blurTypeToBackground[blurType] ?? blurTypeToBackground.regular;
+  const overlay = overlayColor ? { backgroundColor: overlayColor } : undefined;
+  const maskGradient = getMaskGradient(direction, startOffset);
+
+  const blurStyle = {
+    backgroundColor: tint,
+    backdropFilter: `blur(${blurPx}px)`,
+    WebkitBackdropFilter: `blur(${blurPx}px)`,
+    maskImage: maskGradient,
+    WebkitMaskImage: maskGradient,
+  };
+
+  if (!Children.count(children)) {
+    return (
+      <View
+        style={[style, overlay, blurStyle as Record<string, unknown>]}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <View style={[styles.container, style, overlay]} {...props}>
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          blurStyle as Record<string, unknown>,
+        ]}
+      />
+      {children}
+    </View>
+  );
+};
+
+export default ProgressiveBlurView;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+});

--- a/src/ProgressiveBlurView.web.tsx
+++ b/src/ProgressiveBlurView.web.tsx
@@ -177,6 +177,7 @@ export const ProgressiveBlurView: React.FC<ProgressiveBlurViewProps> = ({
   const maskGradient = getMaskGradient(direction, startOffset);
 
   const blurStyle: Record<string, unknown> = {
+    zIndex: 1,
     backgroundColor: tint,
     backdropFilter: `blur(${blurPx}px)`,
     WebkitBackdropFilter: `blur(${blurPx}px)`,

--- a/src/VibrancyView.tsx
+++ b/src/VibrancyView.tsx
@@ -41,6 +41,18 @@ export interface VibrancyViewProps {
  *
  * On iOS, this uses UIVibrancyEffect.
  * On Android, this falls back to a simple View (or BlurView behavior if implemented).
+ *
+ * @example
+ * ```tsx
+ * <VibrancyView
+ *   blurType="light"
+ *   blurAmount={20}
+ *   style={{ flex: 1 }}
+ * >
+ *   <Text>Content on top of vibrancy view</Text>
+ *   <Button title="Interactive Button" onPress={() => {}} />
+ * </VibrancyView>
+ * ```
  */
 export const VibrancyView: React.FC<VibrancyViewProps> = ({
   blurType = 'xlight',

--- a/src/VibrancyView.web.tsx
+++ b/src/VibrancyView.web.tsx
@@ -4,9 +4,32 @@ import type { BlurType } from './ReactNativeBlurViewNativeComponent';
 import { BlurView } from './BlurView.web';
 
 export interface VibrancyViewProps {
+  /**
+   * @description The type of blur effect to apply
+   *
+   * @default 'xlight'
+   */
   blurType?: BlurType;
+
+  /**
+   * @description The intensity of the blur effect (0-100)
+   *
+   * @default 10
+   */
   blurAmount?: number;
+
+  /**
+   * @description style object for the vibrancy view
+   *
+   * @default undefined
+   */
   style?: StyleProp<ViewStyle>;
+
+  /**
+   * @description Child components to render inside the vibrancy view
+   *
+   * @default undefined
+   */
   children?: React.ReactNode;
 }
 
@@ -16,6 +39,18 @@ export interface VibrancyViewProps {
  * iOS uses UIVibrancyEffect which makes content "vibrant" against a blurred
  * background. On web we fall back to BlurView (same approach as the Android
  * fallback in the native implementation).
+ *
+ * @example
+ * ```tsx
+ * <VibrancyView
+ *   blurType="light"
+ *   blurAmount={20}
+ *   style={{ flex: 1 }}
+ * >
+ *   <Text>Content on top of vibrancy view</Text>
+ *   <Button title="Interactive Button" onPress={() => {}} />
+ * </VibrancyView>
+ * ```
  */
 export const VibrancyView: React.FC<VibrancyViewProps> = ({
   blurType = 'xlight',

--- a/src/VibrancyView.web.tsx
+++ b/src/VibrancyView.web.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { ViewStyle, StyleProp } from 'react-native';
+import type { BlurType } from './ReactNativeBlurViewNativeComponent';
+import { BlurView } from './BlurView.web';
+
+export interface VibrancyViewProps {
+  blurType?: BlurType;
+  blurAmount?: number;
+  style?: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+}
+
+/**
+ * Web implementation of VibrancyView.
+ *
+ * iOS uses UIVibrancyEffect which makes content "vibrant" against a blurred
+ * background. On web we fall back to BlurView (same approach as the Android
+ * fallback in the native implementation).
+ */
+export const VibrancyView: React.FC<VibrancyViewProps> = ({
+  blurType = 'xlight',
+  blurAmount = 10,
+  style,
+  children,
+  ...props
+}) => {
+  return (
+    <BlurView
+      blurType={blurType}
+      blurAmount={blurAmount}
+      style={style}
+      {...props}
+    >
+      {children}
+    </BlurView>
+  );
+};

--- a/src/VibrancyView.web.tsx
+++ b/src/VibrancyView.web.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ViewStyle, StyleProp } from 'react-native';
+import { type ViewStyle, type StyleProp, StyleSheet } from 'react-native';
 import type { BlurType } from './ReactNativeBlurViewNativeComponent';
 import { BlurView } from './BlurView.web';
 
@@ -63,10 +63,16 @@ export const VibrancyView: React.FC<VibrancyViewProps> = ({
     <BlurView
       blurType={blurType}
       blurAmount={blurAmount}
-      style={style}
+      style={[styles.container, style]}
       {...props}
     >
       {children}
     </BlurView>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    zIndex: 1,
+  },
+});

--- a/src/index.web.tsx
+++ b/src/index.web.tsx
@@ -2,9 +2,7 @@
 // These are type-only imports and are erased at compile time,
 // so they do not pull in any native code at runtime.
 export type { BlurType } from './ReactNativeBlurViewNativeComponent';
-export type {
-  ProgressiveBlurDirection,
-} from './ReactNativeProgressiveBlurViewNativeComponent';
+export type { ProgressiveBlurDirection } from './ReactNativeProgressiveBlurViewNativeComponent';
 export type { GlassType } from './ReactNativeLiquidGlassViewNativeComponent';
 export type { ValueChangeEvent } from './ReactNativeBlurSwitchNativeComponent';
 

--- a/src/index.web.tsx
+++ b/src/index.web.tsx
@@ -1,0 +1,28 @@
+// Types re-exported from native component definitions.
+// These are type-only imports and are erased at compile time,
+// so they do not pull in any native code at runtime.
+export type { BlurType } from './ReactNativeBlurViewNativeComponent';
+export type {
+  ProgressiveBlurDirection,
+} from './ReactNativeProgressiveBlurViewNativeComponent';
+export type { GlassType } from './ReactNativeLiquidGlassViewNativeComponent';
+export type { ValueChangeEvent } from './ReactNativeBlurSwitchNativeComponent';
+
+// Components
+export { BlurView, BlurView as default } from './BlurView.web';
+export type { BlurViewProps } from './BlurView.web';
+
+export { VibrancyView } from './VibrancyView.web';
+export type { VibrancyViewProps } from './VibrancyView.web';
+
+export { ProgressiveBlurView } from './ProgressiveBlurView.web';
+export type { ProgressiveBlurViewProps } from './ProgressiveBlurView.web';
+
+export { LiquidGlassView } from './LiquidGlassView.web';
+export type { LiquidGlassViewProps } from './LiquidGlassView.web';
+
+export { LiquidGlassContainer } from './LiquidGlassContainer.web';
+export type { LiquidGlassContainerProps } from './LiquidGlassContainer.web';
+
+export { BlurSwitch } from './BlurSwitch.web';
+export type { BlurSwitchProps } from './BlurSwitch.web';


### PR DESCRIPTION
## Summary

Adds web platform support for all library components using CSS `backdrop-filter`. This enables `@sbaiahmed1/react-native-blur` to work in React Native for Web projects without any additional configuration.

Closes #79

## Approach

Each component gets a `.web.tsx` platform-specific file that Metro/webpack automatically resolves when bundling for web. A dedicated `index.web.tsx` entry point re-exports web components and type-only re-exports from native component definitions (erased at compile time).

### Components implemented

| Component | Web implementation |
|---|---|
| **BlurView** | CSS `backdrop-filter: blur(Npx)` + semi-transparent `backgroundColor` tint derived from `blurType` |
| **VibrancyView** | Falls back to BlurView (same strategy as the Android fallback) |
| **ProgressiveBlurView** | `backdrop-filter` + CSS `mask-image` with `linear-gradient` for directional blur |
| **LiquidGlassView** | `backdrop-filter: blur(40px) saturate(180%)` with tint overlay for glass effect |
| **LiquidGlassContainer** | Plain `View` with `gap` spacing (no native glass grouping API on web) |
| **BlurSwitch** | React Native's built-in `Switch` component |

### BlurType mapping

All 21 `BlurType` values are mapped to appropriate `rgba()` background colours that approximate native iOS `UIVisualEffectView` tints:

- **Light variants** (`xlight`, `light`, `*MaterialLight`) → white-based overlays with increasing opacity
- **Dark variants** (`dark`, `extraDark`, `*MaterialDark`) → black-based overlays with increasing opacity
- **System materials** → graduated opacity matching the iOS ultra-thin → chrome hierarchy

### ProgressiveBlurView direction support

The `direction` prop maps to CSS `mask-image` gradients:
- `blurredTopClearBottom` → `linear-gradient(to bottom, black, transparent)`
- `blurredBottomClearTop` → `linear-gradient(to top, black, transparent)`
- `blurredCenterClearTopAndBottom` → gradient with transparent edges and opaque center

The `startOffset` prop controls where the gradient begins.

## Files added

- `src/BlurView.web.tsx`
- `src/VibrancyView.web.tsx`
- `src/ProgressiveBlurView.web.tsx`
- `src/LiquidGlassView.web.tsx`
- `src/LiquidGlassContainer.web.tsx`
- `src/BlurSwitch.web.tsx`
- `src/index.web.tsx`

## Browser support

CSS `backdrop-filter` is supported in all modern browsers:
- Chrome 76+, Edge 79+, Firefox 103+, Safari 9+ (with `-webkit-` prefix)
- [Can I Use: backdrop-filter](https://caniuse.com/css-backdrop-filter) — ~96% global support

## Notes

- Zero new dependencies — only uses `react-native` and CSS
- All props from native components are accepted (unused web-only props are silently ignored for API compatibility)
- TypeScript strict mode compatible
- `blurAmount` is clamped to 0–100 range matching the native behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web implementations added for blur/glass UI: BlurView, ProgressiveBlurView, VibrancyView, LiquidGlassView, LiquidGlassContainer, and a blur-styled Switch — all available via a unified web API surface.
* **Documentation**
  * Platform and prop docs clarified with iOS/Web notes, added usage examples, browser compatibility guidance, and minor JSDoc refinements for props and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->