### PR TITLE
fix: remove children wrapper in BlurView iOS fallback to respect layo…

### DIFF
--- a/src/BlurView.tsx
+++ b/src/BlurView.tsx
@@ -129,8 +129,7 @@ export const BlurView: React.FC<BlurViewProps> = ({
         {...commonProps}
         {...props}
       />
-      {/* Content positioned relatively on top when device is not Android */}
-      <View style={styles.children}>{children}</View>
+      {children}
     </View>
   );
 };
@@ -141,9 +140,5 @@ const styles = StyleSheet.create({
   container: {
     position: 'relative',
     overflow: 'hidden',
-  },
-  children: {
-    position: 'relative',
-    zIndex: 1,
   },
 });


### PR DESCRIPTION
releated to https://github.com/sbaiahmed1/react-native-blur/issues/95

<img width="740" height="846" alt="image" src="https://github.com/user-attachments/assets/a02646d8-862b-45d3-9528-7be0c1f3aa98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified rendering structure of blur effect components on iOS and non-Android platforms. Content elements are now rendered directly over the blurred background without intermediate wrapper containers. Removed associated styling rules and positioning logic previously applied to wrapper elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->