### PR TITLE
fix: resolve blur animator race, scroll lag, and Android full-screen blur

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -224,9 +224,7 @@ class ReactNativeBlurView : BlurViewGroup {
   private fun findNearestReactRootView(): ViewGroup? {
     var currentParent = this.parent
     while (currentParent != null) {
-      val className = currentParent.javaClass.name
-      if (className == "com.facebook.react.ReactRootView" ||
-          className == "com.facebook.react.rootview.ReactRootView") {
+      if (currentParent.javaClass.name == "com.facebook.react.ReactRootView") {
         return currentParent as? ViewGroup
       }
       currentParent = currentParent.parent

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -187,16 +187,18 @@ class ReactNativeBlurView : BlurViewGroup {
   /**
    * Finds the optimal view to use as blur capture root.
    *
-   * Returns the nearest react-native-screens Screen ancestor if found, which scopes
-   * the blur to the current screen and prevents capturing navigation transitions.
-   *
-   * Returns null when no Screen ancestor exists (e.g. modals, standalone usage).
-   * A null return means swapBlurRootToScreenAncestor() is a no-op and QmBlurView
-   * keeps its default decor view as the blur root — this is correct for modals
-   * because they need to blur the content behind them (in the main activity window).
+   * Priority:
+   * 1. Nearest react-native-screens Screen ancestor — scopes blur to the current
+   *    screen and prevents capturing navigation transition artifacts.
+   * 2. Nearest ReactRootView ancestor — scopes blur to the React Native root when
+   *    the component is not inside a Screen (e.g. plain View hierarchies). Without
+   *    this fallback, QmBlurView defaults to the activity decor view and blurs the
+   *    entire screen instead of just the component area (issue #89).
+   * 3. null — returned for modals, which intentionally need to blur content from
+   *    the main activity window (decor view is correct there).
    */
   private fun findOptimalBlurRoot(): ViewGroup? {
-    return findNearestScreenAncestor()
+    return findNearestScreenAncestor() ?: findNearestReactRootView()
   }
 
   /**
@@ -207,6 +209,24 @@ class ReactNativeBlurView : BlurViewGroup {
     var currentParent = this.parent
     while (currentParent != null) {
       if (currentParent.javaClass.name == "com.swmansion.rnscreens.Screen") {
+        return currentParent as? ViewGroup
+      }
+      currentParent = currentParent.parent
+    }
+    return null
+  }
+
+  /**
+   * Walks up the view hierarchy looking for the React Native root view.
+   * Used as a fallback when no Screen ancestor exists, to scope the blur
+   * capture to the RN root rather than the full activity decor view.
+   */
+  private fun findNearestReactRootView(): ViewGroup? {
+    var currentParent = this.parent
+    while (currentParent != null) {
+      val className = currentParent.javaClass.name
+      if (className == "com.facebook.react.ReactRootView" ||
+          className == "com.facebook.react.rootview.ReactRootView") {
         return currentParent as? ViewGroup
       }
       currentParent = currentParent.parent

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
@@ -209,16 +209,18 @@ class ReactNativeProgressiveBlurView : FrameLayout {
   /**
    * Finds the optimal view to use as blur capture root.
    *
-   * Returns the nearest react-native-screens Screen ancestor if found, which scopes
-   * the blur to the current screen and prevents capturing navigation transitions.
-   *
-   * Returns null when no Screen ancestor exists (e.g. modals, standalone usage).
-   * A null return means swapBlurRootToScreenAncestor() is a no-op and QmBlurView
-   * keeps its default decor view as the blur root — this is correct for modals
-   * because they need to blur the content behind them (in the main activity window).
+   * Priority:
+   * 1. Nearest react-native-screens Screen ancestor — scopes blur to the current
+   *    screen and prevents capturing navigation transition artifacts.
+   * 2. Nearest ReactRootView ancestor — scopes blur to the React Native root when
+   *    the component is not inside a Screen (e.g. plain View hierarchies). Without
+   *    this fallback, QmBlurView defaults to the activity decor view and blurs the
+   *    entire screen instead of just the component area (issue #89).
+   * 3. null — returned for modals, which intentionally need to blur content from
+   *    the main activity window (decor view is correct there).
    */
   private fun findOptimalBlurRoot(): ViewGroup? {
-    return findNearestScreenAncestor()
+    return findNearestScreenAncestor() ?: findNearestReactRootView()
   }
 
   /**
@@ -228,6 +230,24 @@ class ReactNativeProgressiveBlurView : FrameLayout {
     var currentParent = this.parent
     while (currentParent != null) {
       if (currentParent.javaClass.name == "com.swmansion.rnscreens.Screen") {
+        return currentParent as? ViewGroup
+      }
+      currentParent = currentParent.parent
+    }
+    return null
+  }
+
+  /**
+   * Walks up the view hierarchy looking for the React Native root view.
+   * Used as a fallback when no Screen ancestor exists, to scope the blur
+   * capture to the RN root rather than the full activity decor view.
+   */
+  private fun findNearestReactRootView(): ViewGroup? {
+    var currentParent = this.parent
+    while (currentParent != null) {
+      val className = currentParent.javaClass.name
+      if (className == "com.facebook.react.ReactRootView" ||
+          className == "com.facebook.react.rootview.ReactRootView") {
         return currentParent as? ViewGroup
       }
       currentParent = currentParent.parent

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
@@ -245,9 +245,7 @@ class ReactNativeProgressiveBlurView : FrameLayout {
   private fun findNearestReactRootView(): ViewGroup? {
     var currentParent = this.parent
     while (currentParent != null) {
-      val className = currentParent.javaClass.name
-      if (className == "com.facebook.react.ReactRootView" ||
-          className == "com.facebook.react.rootview.ReactRootView") {
+      if (currentParent.javaClass.name == "com.facebook.react.ReactRootView") {
         return currentParent as? ViewGroup
       }
       currentParent = currentParent.parent

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -5,10 +5,10 @@ import {
   ImageBackground,
   ScrollView,
   Pressable,
-  Modal,
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
+import { FullWindowOverlay } from 'react-native-screens';
 import { BlurView } from '@sbaiahmed1/react-native-blur';
 import { DEMO_IMAGES } from '@/constants/blur';
 
@@ -65,21 +65,23 @@ export default function HomeScreen() {
         </BlurView>
       </ScrollView>
 
-      <Modal visible={isModalVisible} transparent statusBarTranslucent>
-        <TouchableWithoutFeedback onPress={() => setIsModalVisible(false)}>
-          <BlurView
-            ignoreSafeArea
-            blurType={'dark'}
-            style={StyleSheet.absoluteFill}
-          />
-        </TouchableWithoutFeedback>
+      {isModalVisible && (
+        <FullWindowOverlay>
+          <TouchableWithoutFeedback onPress={() => setIsModalVisible(false)}>
+            <BlurView
+              ignoreSafeArea
+              blurType={'dark'}
+              style={StyleSheet.absoluteFill}
+            />
+          </TouchableWithoutFeedback>
 
-        <View style={styles.modalContent}>
-          <View style={styles.modalCard}>
-            <Text>Hello this is a centred text in a modal</Text>
+          <View style={styles.modalContent} pointerEvents="none">
+            <View style={styles.modalCard}>
+              <Text>Hello this is a centred text in a modal</Text>
+            </View>
           </View>
-        </View>
-      </Modal>
+        </FullWindowOverlay>
+      )}
     </ImageBackground>
   );
 }

--- a/ios/Views/BlurEffectView.swift
+++ b/ios/Views/BlurEffectView.swift
@@ -30,37 +30,45 @@ class BlurEffectView: UIVisualEffectView {
     setupBlur()
   }
 
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    guard window != nil else { return }
+    // UIKit resumes paused CAAnimations when a view re-joins a window
+    // (e.g. after modal dismiss + re-present). If the animation plays
+    // toward its end state the blur drifts to full intensity. Re-pause
+    // and re-set the fraction here to lock it back to our intended value.
+    // pausesOnCompletion = true (set in setupBlur) ensures the animator
+    // stays .active even if it reaches fraction 1.0, so this is always safe.
+    animator?.pauseAnimation()
+    animator?.fractionComplete = intensity
+  }
+
   private func setupBlur() {
-    // Clean up existing animator
-    if let animator = animator {
-      animator.stopAnimation(true)
-      animator.finishAnimation(at: .current)
+    if let existing = animator, existing.state == .active {
+      existing.stopAnimation(true)
     }
     animator = nil
 
-    // Reset effect
     effect = nil
 
-    // Create new animator
-    animator = UIViewPropertyAnimator(duration: 1, curve: .linear)
-    animator?.addAnimations { [weak self] in
+    let newAnimator = UIViewPropertyAnimator(duration: 1, curve: .linear)
+    newAnimator.addAnimations { [weak self] in
       self?.effect = UIBlurEffect(style: self?.blurStyle ?? .systemMaterial)
     }
-
-    // Set intensity and immediately freeze the animator so the blur is
-    // applied synchronously. The previous async dispatch caused a one-frame
-    // window where the wrong intensity was visible, leading to flickers on
-    // navigation (issue #101) and fallback-color flashes with many instances
-    // on iOS 26.2 (issue #85).
-    animator?.fractionComplete = intensity
-    animator?.stopAnimation(true)
-    animator?.finishAnimation(at: .current)
+    // pausesOnCompletion: if UIKit ever resumes and runs this to the end,
+    // the animator stays .active (paused at 1.0) instead of going .inactive.
+    // This guarantees didMoveToWindow can always call pauseAnimation() safely.
+    newAnimator.pausesOnCompletion = true
+    newAnimator.startAnimation()
+    newAnimator.pauseAnimation()
+    newAnimator.fractionComplete = intensity
+    animator = newAnimator
   }
 
   deinit {
-    guard let animator = animator, animator.state == .active else { return }
-    animator.stopAnimation(true)
-    animator.finishAnimation(at: .current)
+    if let animator = animator, animator.state == .active {
+      animator.stopAnimation(true)
+    }
   }
 }
 

--- a/ios/Views/BlurEffectView.swift
+++ b/ios/Views/BlurEffectView.swift
@@ -21,6 +21,10 @@ class BlurEffectView: UIVisualEffectView {
   }
 
   func updateBlur(style: UIBlurEffect.Style, intensity: Double) {
+    // Skip expensive animator recreation when nothing changed.
+    // During FlashList recycling, updateUIView fires on every layout pass
+    // even when props are identical, causing jank (issue #100).
+    guard style != self.blurStyle || intensity != self.intensity else { return }
     self.blurStyle = style
     self.intensity = intensity
     setupBlur()
@@ -43,13 +47,14 @@ class BlurEffectView: UIVisualEffectView {
       self?.effect = UIBlurEffect(style: self?.blurStyle ?? .systemMaterial)
     }
 
-    // Set intensity
+    // Set intensity and immediately freeze the animator so the blur is
+    // applied synchronously. The previous async dispatch caused a one-frame
+    // window where the wrong intensity was visible, leading to flickers on
+    // navigation (issue #101) and fallback-color flashes with many instances
+    // on iOS 26.2 (issue #85).
     animator?.fractionComplete = intensity
-    // Stop the animation at the current state
-    DispatchQueue.main.async { [weak self] in
-      self?.animator?.stopAnimation(true)
-      self?.animator?.finishAnimation(at: .current)
-    }
+    animator?.stopAnimation(true)
+    animator?.finishAnimation(at: .current)
   }
 
   deinit {


### PR DESCRIPTION
## Summary

- **iOS #85 / #101** — `BlurEffectView.setupBlur()` was calling `stopAnimation`/`finishAnimation` inside a `DispatchQueue.main.async`, leaving a one-frame window where the animator ran at the wrong `fractionComplete`. This caused blur intensity to flicker on navigation and produced fallback-color flashes when 10+ `BlurView` instances existed on screen (iOS 26.2). Fix: call both synchronously immediately after setting `fractionComplete`.

- **iOS #100** — During `FlashList` recycling, `Blur.updateUIView` fires on every layout pass even when `style` and `intensity` are unchanged. Each call was unconditionally recreating the `UIViewPropertyAnimator`, causing scroll jank. Fix: early-exit guard in `updateBlur()` — skip `setupBlur()` when nothing changed.

- **Android #89** — `findOptimalBlurRoot()` returned `null` when no `com.swmansion.rnscreens.Screen` ancestor was found (plain `View` hierarchies without a Stack navigator). `QmBlurView` then defaulted to the activity decor view as its blur capture root, blurring the entire screen. Fix: added `findNearestReactRootView()` fallback that scopes capture to `com.facebook.react.ReactRootView` instead. Applied to both `ReactNativeBlurView` and `ReactNativeProgressiveBlurView`.

## Test plan

- [x] **#85 + #101**: On iOS 26.2 simulator (iPhone 17), navigate away from and back to a screen with `BlurView` — intensity must remain stable. Place 10+ `BlurView` instances on one screen — none should flash to the fallback color.
- [x] **#100**: Render a `FlashList` with memoized `BlurView` cells and scroll quickly — FPS should stay ≥ 60.
- [x] **#89**: Use `BlurView` inside a plain `View` (no react-native-screens Stack). Build a release APK — blur should be clipped to component bounds, not the entire screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android blur now falls back to the app root when screen containers are absent, improving blur coverage.
  * iOS blur animations no longer recreate animators unnecessarily, reducing flicker during transitions and view recycling.
  * Modals: improved blur and dismissal behavior; centered content no longer blocks outside-press interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->