### PR TITLE
fix(android): change blur type color based by ui mode

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/BlurType.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/BlurType.kt
@@ -1,5 +1,6 @@
 package com.sbaiahmed1.reactnativeblur
 
+import android.content.res.Configuration
 import android.graphics.Color
 
 /**
@@ -9,51 +10,52 @@ import android.graphics.Color
 enum class BlurType(val overlayColor: Int) {
   XLIGHT(Color.argb(140, 240, 240, 240)),
   LIGHT(Color.argb(42, 255, 255, 255)),
-  DARK(Color.argb(120, 25, 25, 25)),
+  DARK(Color.argb(120, 26, 22, 22)),
   EXTRA_DARK(Color.argb(160, 35, 35, 35)),
-  REGULAR(Color.argb(35, 255, 255, 255)),
-  PROMINENT(Color.argb(130, 240, 240, 240)),
-  SYSTEM_ULTRA_THIN_MATERIAL(Color.argb(75, 240, 240, 240)),
-  SYSTEM_ULTRA_THIN_MATERIAL_LIGHT(Color.argb(77, 240, 240, 240)),
+  REGULAR_LIGHT(Color.argb(35, 255, 255, 255)),
+  REGULAR_DARK(Color.argb(35, 28, 28, 30)),
+  PROMINENT_LIGHT(Color.argb(140, 240, 240, 240)),
+  PROMINENT_DARK(Color.argb(140, 28, 28, 30)),
+  SYSTEM_ULTRA_THIN_MATERIAL_LIGHT(Color.argb(75, 240, 240, 240)),
   SYSTEM_ULTRA_THIN_MATERIAL_DARK(Color.argb(65, 40, 40, 40)),
-  SYSTEM_THIN_MATERIAL(Color.argb(102, 240, 240, 240)),
-  SYSTEM_THIN_MATERIAL_LIGHT(Color.argb(105, 240, 240, 240)),
+  SYSTEM_THIN_MATERIAL_LIGHT(Color.argb(102, 240, 240, 240)),
   SYSTEM_THIN_MATERIAL_DARK(Color.argb(102, 35, 35, 35)),
-  SYSTEM_MATERIAL(Color.argb(130, 242, 242, 242)),
-  SYSTEM_MATERIAL_LIGHT(Color.argb(130, 245, 245, 245)),
+  SYSTEM_MATERIAL_LIGHT(Color.argb(140, 245, 245, 245)),
   SYSTEM_MATERIAL_DARK(Color.argb(215, 65, 60, 60)),
-  SYSTEM_THICK_MATERIAL(Color.argb(160, 240, 240, 240)),
-  SYSTEM_THICK_MATERIAL_LIGHT(Color.argb(160, 242, 242, 242)),
+  SYSTEM_THICK_MATERIAL_LIGHT(Color.argb(210, 248, 248, 248)),
   SYSTEM_THICK_MATERIAL_DARK(Color.argb(160, 35, 35, 35)),
-  SYSTEM_CHROME_MATERIAL(Color.argb(135, 240, 240, 240)),
-  SYSTEM_CHROME_MATERIAL_LIGHT(Color.argb(135, 242, 242, 242)),
-  SYSTEM_CHROME_MATERIAL_DARK(Color.argb(90, 32, 32, 32));
+  SYSTEM_CHROME_MATERIAL_LIGHT(Color.argb(165, 248, 248, 248)),
+  SYSTEM_CHROME_MATERIAL_DARK(Color.argb(100, 32, 32, 32));
 
   companion object {
     /**
      * Get BlurType from string, with fallback to LIGHT for unknown types.
+     * Uses the provided configuration to determine if dark mode is active for
+     * appropriate defaults.
      */
-    fun fromString(type: String): BlurType {
+    fun fromString(type: String, configuration: Configuration): BlurType {
+      val isDarkMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+
       return when (type.lowercase()) {
         "xlight" -> XLIGHT
         "light" -> LIGHT
         "dark" -> DARK
         "extradark" -> EXTRA_DARK
-        "regular" -> REGULAR
-        "prominent" -> PROMINENT
-        "systemultrathinmaterial" -> SYSTEM_ULTRA_THIN_MATERIAL
+        "regular" -> if (isDarkMode) REGULAR_DARK else REGULAR_LIGHT
+        "prominent" -> if (isDarkMode) PROMINENT_DARK else PROMINENT_LIGHT
+        "systemultrathinmaterial" -> if (isDarkMode) SYSTEM_ULTRA_THIN_MATERIAL_DARK else SYSTEM_ULTRA_THIN_MATERIAL_LIGHT
         "systemultrathinmateriallight" -> SYSTEM_ULTRA_THIN_MATERIAL_LIGHT
         "systemultrathinmaterialdark" -> SYSTEM_ULTRA_THIN_MATERIAL_DARK
-        "systemthinmaterial" -> SYSTEM_THIN_MATERIAL
+        "systemthinmaterial" -> if (isDarkMode) SYSTEM_THIN_MATERIAL_DARK else SYSTEM_THIN_MATERIAL_LIGHT
         "systemthinmateriallight" -> SYSTEM_THIN_MATERIAL_LIGHT
         "systemthinmaterialdark" -> SYSTEM_THIN_MATERIAL_DARK
-        "systemmaterial" -> SYSTEM_MATERIAL
+        "systemmaterial" -> if (isDarkMode) SYSTEM_MATERIAL_DARK else SYSTEM_MATERIAL_LIGHT
         "systemmateriallight" -> SYSTEM_MATERIAL_LIGHT
         "systemmaterialdark" -> SYSTEM_MATERIAL_DARK
-        "systemthickmaterial" -> SYSTEM_THICK_MATERIAL
+        "systemthickmaterial" -> if (isDarkMode) SYSTEM_THICK_MATERIAL_DARK else SYSTEM_THICK_MATERIAL_LIGHT
         "systemthickmateriallight" -> SYSTEM_THICK_MATERIAL_LIGHT
         "systemthickmaterialdark" -> SYSTEM_THICK_MATERIAL_DARK
-        "systemchromematerial" -> SYSTEM_CHROME_MATERIAL
+        "systemchromematerial" -> if (isDarkMode) SYSTEM_CHROME_MATERIAL_DARK else SYSTEM_CHROME_MATERIAL_LIGHT
         "systemchromemateriallight" -> SYSTEM_CHROME_MATERIAL_LIGHT
         "systemchromematerialdark" -> SYSTEM_CHROME_MATERIAL_DARK
         else -> XLIGHT // default fallback

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -472,6 +472,9 @@ class ReactNativeBlurView : BlurViewGroup {
   override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
 
-    setBlurType(currentBlurType)
+    if (viewType == "blur") {
+      // Re-apply blur type to update overlay color based on new configuration
+      setBlurType(currentBlurType)
+    }
   }
 }

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -1,6 +1,7 @@
 package com.sbaiahmed1.reactnativeblur
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.Outline
 import android.util.AttributeSet
@@ -35,6 +36,7 @@ class ReactNativeBlurView : BlurViewGroup {
   private var glassOpacity: Float = 1.0f
   private var viewType: String = "blur"
   private var glassType: String = "clear"
+  private var currentBlurType: String = "xlight"
   private var isBlurInitialized: Boolean = false
   private var initRunnable: Runnable? = null
 
@@ -275,7 +277,8 @@ class ReactNativeBlurView : BlurViewGroup {
    * @param type The blur type string (case-insensitive)
    */
   fun setBlurType(type: String) {
-    val blurType = BlurType.fromString(type)
+    currentBlurType = type
+    val blurType = BlurType.fromString(type, resources.configuration)
     currentOverlayColor = blurType.overlayColor
     logDebug("setBlurType: $type -> ${blurType.name}")
 
@@ -459,5 +462,16 @@ class ReactNativeBlurView : BlurViewGroup {
     // We override this to prevent the superclass (BlurViewGroup/FrameLayout) from
     // re-positioning children based on its own logic (e.g. gravity), which would
     // conflict with React Native's layout.
+  }
+
+  /**
+   * Handle configuration changes, such as dark mode or orientation changes.
+   * This ensures the blur view updates its overlay color based on the new
+   * configuration.
+   */
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    setBlurType(currentBlurType)
   }
 }

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
@@ -1,6 +1,7 @@
 package com.sbaiahmed1.reactnativeblur
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.LinearGradient
@@ -31,6 +32,7 @@ class ReactNativeProgressiveBlurView : FrameLayout {
 
   private var currentBlurRadius = DEFAULT_BLUR_RADIUS
   private var currentOverlayColor = Color.TRANSPARENT
+  private var currentBlurType = "xlight"
   private var currentDirection = "topToBottom"
   private var currentStartOffset = 0.0f
   private var hasExplicitBackground: Boolean = false
@@ -376,6 +378,17 @@ class ReactNativeProgressiveBlurView : FrameLayout {
   }
 
   /**
+   * Handle configuration changes, such as dark mode or orientation changes.
+   * This ensures the blur view updates its overlay color based on the new
+   * configuration.
+   */
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    setBlurType(currentBlurType)
+  }
+
+  /**
    * Cleanup method to prevent memory leaks.
    * Resets initialization state so blur is re-initialized on next attach.
    */
@@ -476,7 +489,8 @@ class ReactNativeProgressiveBlurView : FrameLayout {
    * @param type The blur type string (case-insensitive)
    */
   fun setBlurType(type: String) {
-    val blurType = BlurType.fromString(type)
+    currentBlurType = type
+    val blurType = BlurType.fromString(type, resources.configuration)
     currentOverlayColor = blurType.overlayColor
     logDebug("setBlurType: $type -> ${blurType.name} -> ${Integer.toHexString(currentOverlayColor)}")
 

--- a/src/BlurView.tsx
+++ b/src/BlurView.tsx
@@ -23,9 +23,9 @@ export interface BlurViewProps {
   /**
    * @description Fallback color when reduced transparency is enabled
    *
-   * Accepts hex color strings like `#FFFFFF`
-   *
    * @default '#FFFFFF'
+   *
+   * @platform iOS
    */
   reducedTransparencyFallbackColor?: string;
 

--- a/src/LiquidGlassContainer.tsx
+++ b/src/LiquidGlassContainer.tsx
@@ -4,10 +4,11 @@ import ReactNativeLiquidGlassContainer from './ReactNativeLiquidGlassContainerNa
 
 export interface LiquidGlassContainerProps extends ViewProps {
   /**
-   * The spacing value for the glass container effect
-   * Platform: iOS only (iOS 26+)
+   * @description The spacing value for the glass container effect
    *
    * @default 0
+   *
+   * @platform iOS
    */
   spacing?: number;
 }

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -12,7 +12,7 @@ export interface LiquidGlassViewProps {
    *
    * @default 'clear'
    *
-   * @platform iOS
+   * @platform iOS 26+
    */
   glassType?: GlassType;
 

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -8,62 +8,72 @@ import BlurView from './BlurView';
 
 export interface LiquidGlassViewProps {
   /**
-   * The type of glass effect to apply
-   * Platform: iOS 26+ only
+   * @description The type of glass effect to apply
    *
    * @default 'clear'
+   *
+   * @platform iOS
    */
   glassType?: GlassType;
 
   /**
-   * The tint color of the glass effect
-   * Accepts hex color strings like '#FFFFFF' or color names
-   * Platform: iOS 26+ only
+   * @description The tint color of the glass effect. Accepts hex color strings
+   * like '#FFFFFF' or color names
    *
    * @default 'clear'
+   *
+   * @platform iOS 26+
    */
   glassTintColor?: string;
 
   /**
-   * The opacity of the glass effect (0-1)
-   * Platform: iOS 26+ only
+   * @description The opacity of the glass effect (0-1)
    *
    * @default 1.0
+   *
+   * @platform iOS 26+
    */
   glassOpacity?: number;
 
   /**
-   * Fallback color when reduced transparency is enabled or on older iOS versions
-   * Accepts hex color strings like '#FFFFFF'
-   * Platform: iOS only
+   * @description Fallback color when reduced transparency is enabled or on
+   * older iOS versions
    *
    * @default '#FFFFFF'
+   *
+   * @platform iOS
    */
   reducedTransparencyFallbackColor?: string;
 
   /**
-   * Whether the glass view should be interactive
-   * Platform: iOS 26+ only
+   * @description Whether the glass view should be interactive
    *
    * @default true
+   *
+   * @platform iOS
    */
   isInteractive?: boolean;
 
   /**
-   * Whether the glass view should ignore safe area insets
-   * Platform: iOS 26+ only
+   * @description Whether the glass view should ignore safe area insets
    *
    * @default false
+   *
+   * @platform iOS
    */
   ignoreSafeArea?: boolean;
 
   /**
-   * Style object for the liquid glass view
+   * @description Style object for the liquid glass view
+   *
+   * @default undefined
    */
   style?: StyleProp<ViewStyle>;
 
   /**
    * Child components to render inside the liquid glass view
+   *
+   * @default undefined
    */
   children?: React.ReactNode;
 }

--- a/src/ProgressiveBlurView.tsx
+++ b/src/ProgressiveBlurView.tsx
@@ -44,9 +44,9 @@ export interface ProgressiveBlurViewProps {
   /**
    * @description Fallback color when reduced transparency is enabled
    *
-   * Accepts hex color strings like `#FFFFFF`
-   *
    * @default '#FFFFFF'
+   *
+   * @platform iOS
    */
   reducedTransparencyFallbackColor?: string;
 

--- a/src/ReactNativeBlurSwitchNativeComponent.ts
+++ b/src/ReactNativeBlurSwitchNativeComponent.ts
@@ -11,49 +11,12 @@ export interface ValueChangeEvent {
 }
 
 interface NativeProps extends ViewProps {
-  /**
-   * The current value of the switch
-   * @default false
-   */
   value?: WithDefault<boolean, false>;
-
-  /**
-   * The intensity of the blur effect (0-100)
-   * @default 10.0
-   */
   blurAmount?: WithDefault<Double, 10.0>;
-
-  /**
-   * The color of the switch thumb
-   * Note: Not supported by the Android implementation (no-op).
-   * Use the native iOS Switch for platform-specific thumb colors.
-   * @default '#FFFFFF'
-   */
   thumbColor?: WithDefault<string, '#FFFFFF'>;
-
-  /**
-   * The track color when switch is off
-   * Note: Not supported by the Android implementation (no-op).
-   * Use the native iOS Switch for platform-specific off-state colors.
-   * @default '#E5E5EA'
-   */
   trackColorOff?: WithDefault<string, '#E5E5EA'>;
-
-  /**
-   * The track color when switch is on
-   * @default '#34C759'
-   */
   trackColorOn?: WithDefault<string, '#34C759'>;
-
-  /**
-   * Whether the switch is disabled
-   * @default false
-   */
   disabled?: WithDefault<boolean, false>;
-
-  /**
-   * Callback invoked when the switch value changes
-   */
   onValueChange?: DirectEventHandler<Readonly<ValueChangeEvent>>;
 }
 

--- a/src/ReactNativeLiquidGlassContainerNativeComponent.ts
+++ b/src/ReactNativeLiquidGlassContainerNativeComponent.ts
@@ -3,11 +3,6 @@ import type { ViewProps } from 'react-native';
 import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
 interface NativeProps extends ViewProps {
-  /**
-   * The spacing value for the glass container effect
-   * Platform: iOS only (iOS 26+)
-   * @default 0
-   */
   spacing?: Double;
 }
 

--- a/src/ReactNativeLiquidGlassViewNativeComponent.ts
+++ b/src/ReactNativeLiquidGlassViewNativeComponent.ts
@@ -8,46 +8,11 @@ import type {
 export type GlassType = 'clear' | 'regular';
 
 interface NativeProps extends ViewProps {
-  /**
-   * The type of glass effect to apply
-   * Platform: iOS only
-   * @default 'clear'
-   */
   glassType?: WithDefault<GlassType, 'clear'>;
-
-  /**
-   * The tint color of the glass effect
-   * Platform: iOS only
-   * @default 'clear'
-   */
   glassTintColor?: WithDefault<string, 'clear'>;
-
-  /**
-   * The opacity of the glass effect (0-1)
-   * Platform: iOS only
-   * @default 1.0
-   */
   glassOpacity?: WithDefault<Double, 1.0>;
-
-  /**
-   * Fallback color when reduced transparency is enabled
-   * Platform: iOS only
-   * @default '#FFFFFF'
-   */
   reducedTransparencyFallbackColor?: WithDefault<string, '#FFFFFF'>;
-
-  /**
-   * Whether the glass view should be interactive
-   * Platform: iOS only
-   * @default true
-   */
   isInteractive?: WithDefault<boolean, true>;
-
-  /**
-   * Whether the glass view should ignore safe area insets
-   * Platform: iOS only
-   * @default true
-   */
   ignoreSafeArea?: WithDefault<boolean, true>;
 }
 


### PR DESCRIPTION
When the UI mode changed for light or dark in Android, the blur types `regular`, `prominent`, `systemultrathinmaterial`, `systemthinmaterial`, `systemmaterial`, `systemthickmaterial`, and `systemchromematerial` must have been changed according to the UI selected. This behavior already exists in iOS, but it has been added in Android now.

In light mode:
<img width="370" height="776" alt="light" src="https://github.com/user-attachments/assets/9f5effb6-2679-4257-94d9-f2ec9680f9eb" />

In dark mode:
<img width="370" height="776" alt="dark" src="https://github.com/user-attachments/assets/a5664661-494a-458b-a489-bafcd08d87fa" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blur effects now automatically adapt to system light and dark mode changes on Android.

* **Documentation**
  * Updated platform availability annotations clarifying iOS-only properties (`reducedTransparencyFallbackColor`, `spacing`).
  * Enhanced property descriptions with structured documentation tags for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->