### PR TITLE
fix(ios): improve rendering of blur effects and handle zero-alpha tint correctly

### DIFF
--- a/ios/Views/BlurEffectView.swift
+++ b/ios/Views/BlurEffectView.swift
@@ -38,6 +38,15 @@ class BlurEffectView: UIVisualEffectView {
     }
   }
 
+  // draw(_:) is called by UIVisualEffectView whenever the effect needs to
+  // refresh (expo-blur's approach). It heals cases the two hooks above miss:
+  // the animator being flushed by an in-place alpha animation while the view
+  // stays in the window and the app stays foreground.
+  override func draw(_ rect: CGRect) {
+    super.draw(rect)
+    rebuildAnimator()
+  }
+
   // Paused animators do not survive backgrounding — the system finishes them,
   // leaving the effect at full intensity (or stripped entirely). Rebuild
   // before the first foreground frame is rendered to avoid a visible flash.

--- a/ios/Views/LiquidGlassContainerView.swift
+++ b/ios/Views/LiquidGlassContainerView.swift
@@ -121,7 +121,14 @@ import UIKit
       
       // Always create a new effect to ensure proper rendering
       let effect = UIGlassEffect(style: style)
-      effect.tintColor = glassTintColor.withAlphaComponent(glassOpacity)
+      // A zero-alpha tint means "no tint". Running it through
+      // withAlphaComponent(glassOpacity) resurrects UIColor.clear (black at
+      // alpha 0) as opaque black (issue #113) — leave the glass untinted.
+      if glassTintColor.cgColor.alpha == 0 {
+        effect.tintColor = nil
+      } else {
+        effect.tintColor = glassTintColor.withAlphaComponent(glassOpacity)
+      }
       effect.isInteractive = isInteractive
       
       glassEffectView?.effect = effect


### PR DESCRIPTION
closes: #113 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blur effects so they recover more reliably while the app is open, reducing cases where the visual treatment could disappear or become stale.
  * Made glass-style tinting respect transparent tint colors, so untinted glass now appears correctly when no tint is intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->