### PR TITLE
fix(android): stop losing view state on detach/re-attach + correctness (audit PR 1/6)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,9 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    // Ship keep rules into the AAR so a consumer app's R8 does not strip the
+    // QmBlurView fields we access by reflection (see consumer-rules.pro).
+    consumerProguardFiles "consumer-rules.pro"
   }
 
   buildFeatures {

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,12 @@
+# Consumer ProGuard/R8 rules shipped inside the AAR and applied automatically
+# to any app that depends on @sbaiahmed1/react-native-blur.
+#
+# ReactNativeBlurView and ReactNativeProgressiveBlurView redirect the blur
+# capture root by reflecting on the bundled QmBlurView library
+# (com.github.qmdeve:qmblurview) by field name: mBaseBlurViewGroup,
+# mDecorView, preDrawListener, mDifferentRoot and mForceRedraw. If R8 renames
+# or removes those fields in a minified release build, the reflection throws
+# NoSuchFieldException, the code silently falls back to capturing the whole
+# activity decor view, and the app regresses to full-screen blur and
+# navigation flicker (issue #89). Keep the library's classes and fields intact.
+-keep class com.qmdeve.blurview.** { *; }

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitch.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitch.kt
@@ -92,17 +92,15 @@ class ReactNativeBlurSwitch : BlurSwitchButtonView {
   }
 
   /**
-   * Called when the view is detached from a window.
-   * Performs cleanup to prevent memory leaks.
-   */
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    cleanup()
-  }
-
-  /**
    * Cleanup method to reset state.
-   * Helps prevent memory leaks and ensures clean state.
+   *
+   * Only called from the view manager's onDropViewInstance, i.e. when React
+   * Native is truly done with this view. It must NOT run on a plain
+   * onDetachedFromWindow: react-native-screens detaches inactive screens and
+   * FlatList's removeClippedSubviews detaches off-screen cells, and the
+   * listeners are only wired in the constructor and createViewInstance. Tearing
+   * them down on detach left the switch permanently unable to report toggles
+   * after the user navigated away and back.
    */
   fun cleanup() {
     setOnCheckedChangeListener(null)

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -105,8 +105,22 @@ class ReactNativeBlurView : BlurViewGroup {
 
     if (isBlurInitialized) return
 
-    swapBlurRootToScreenAncestor()
-    initializeBlur()
+    // Defer the root swap and blur init to the next frame rather than running
+    // them synchronously here. On a re-attach during navigation (react-native
+    // -screens detaches inactive screens), the parent chain up to the Screen
+    // ancestor and the QmBlurView library's own decor-view registration are
+    // not always settled at onAttachedToWindow time, so a synchronous swap
+    // could miss the Screen root and fall back to whole-screen blur. Posting
+    // lets both settle first, matching ReactNativeProgressiveBlurView. The
+    // runnable is tracked so cleanup() can cancel it if the view detaches
+    // again before it runs.
+    val runnable = Runnable {
+      initRunnable = null
+      swapBlurRootToScreenAncestor()
+      initializeBlur()
+    }
+    initRunnable = runnable
+    post(runnable)
   }
 
   private fun swapBlurRootToScreenAncestor() {
@@ -270,6 +284,7 @@ class ReactNativeBlurView : BlurViewGroup {
       } catch (e: Exception) {
         logWarning("Invalid color format for glass tint: $color")
         glassTintColor = Color.TRANSPARENT
+        updateGlassEffect()
       }
     } ?: run {
       glassTintColor = Color.TRANSPARENT
@@ -370,11 +385,14 @@ class ReactNativeBlurView : BlurViewGroup {
 
   private fun updateCornerRadius() {
     try {
+      // Unset per-corner radii use the sentinel -1f (see the field defaults), so
+      // test >= 0: an explicit 0 must override the base radius to square that
+      // corner, only a negative sentinel falls back to baseRadius.
       val baseRadius = convertDpToPx(borderRadius)
-      val topLeft = if (borderTopLeftRadius > 0) convertDpToPx(borderTopLeftRadius) else baseRadius
-      val topRight = if (borderTopRightRadius > 0) convertDpToPx(borderTopRightRadius) else baseRadius
-      val bottomLeft = if (borderBottomLeftRadius > 0) convertDpToPx(borderBottomLeftRadius) else baseRadius
-      val bottomRight = if (borderBottomRightRadius > 0) convertDpToPx(borderBottomRightRadius) else baseRadius
+      val topLeft = if (borderTopLeftRadius >= 0) convertDpToPx(borderTopLeftRadius) else baseRadius
+      val topRight = if (borderTopRightRadius >= 0) convertDpToPx(borderTopRightRadius) else baseRadius
+      val bottomLeft = if (borderBottomLeftRadius >= 0) convertDpToPx(borderBottomLeftRadius) else baseRadius
+      val bottomRight = if (borderBottomRightRadius >= 0) convertDpToPx(borderBottomRightRadius) else baseRadius
 
       super.setTopLeftCornerRadius(topLeft)
       super.setTopRightCornerRadius(topRight)

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
@@ -15,7 +15,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.view.View.MeasureSpec
 import com.qmdeve.blurview.widget.BlurView
-import kotlin.math.max
 
 /**
  * Android implementation of React Native ProgressiveBlurView component.
@@ -33,13 +32,17 @@ class ReactNativeProgressiveBlurView : FrameLayout {
   // xfermode can stay set for the paint's whole lifetime.
   private val dstInXfermode = PorterDuffXfermode(PorterDuff.Mode.DST_IN)
 
+  // Raw blur amount (0-100) as received from JS. Kept separate from
+  // currentBlurRadius because the effective radius also depends on the current
+  // direction (center is scaled down), and direction can change after the
+  // amount is set, so the radius must be derivable at any time.
+  private var currentBlurAmount = DEFAULT_BLUR_RADIUS
   private var currentBlurRadius = DEFAULT_BLUR_RADIUS
   private var currentBlurRounds = DEFAULT_BLUR_ROUNDS
   private var currentOverlayColor = Color.TRANSPARENT
   private var currentBlurType = "xlight"
   private var currentDirection = "topToBottom"
   private var currentStartOffset = 0.0f
-  private var hasExplicitBackground: Boolean = false
   private var isBlurInitialized: Boolean = false
   private var initRunnable: Runnable? = null
   private var swapRootRunnable: Runnable? = null
@@ -304,7 +307,12 @@ class ReactNativeProgressiveBlurView : FrameLayout {
     try {
       val gradient = when (currentDirection) {
         "center" -> {
-          val startEdge = max(currentStartOffset, 0.01f)
+          // Clamp to [0.01, 0.3]: above 0.3 the derived stops
+          // (centerLow = 0.2 + startEdge, centerHigh = 0.8 - startEdge) cross
+          // over, producing a non-monotonic position array that LinearGradient
+          // renders undefined. At 0.3 they meet (0.5, 0.5), the tightest valid
+          // center band.
+          val startEdge = currentStartOffset.coerceIn(0.01f, 0.3f)
           val endEdge = 1f - startEdge
           val centerLow = 0.2f + startEdge
           val centerHigh = 0.8f - startEdge
@@ -410,7 +418,6 @@ class ReactNativeProgressiveBlurView : FrameLayout {
    * Resets initialization state so blur is re-initialized on next attach.
    */
   fun cleanup() {
-    hasExplicitBackground = false
     isBlurInitialized = false
     initRunnable?.let { removeCallbacks(it) }
     initRunnable = null
@@ -443,13 +450,25 @@ class ReactNativeProgressiveBlurView : FrameLayout {
    * @param amount The blur amount value (0-100), will be mapped to Android's 0-25 radius range
    */
   fun setBlurAmount(amount: Float) {
-    var radius = mapBlurAmountToRadius(amount)
+    currentBlurAmount = amount
+    applyBlurRadius()
+  }
+
+  /**
+   * Derives the effective blur radius from the raw amount and the current
+   * direction, then applies it. Called from both setBlurAmount and setDirection
+   * so the center-direction scale-down is applied regardless of the order in
+   * which those two props arrive (the JS wrapper emits blurAmount before
+   * direction, so applying the factor only inside setBlurAmount missed it).
+   */
+  private fun applyBlurRadius() {
+    var radius = mapBlurAmountToRadius(currentBlurAmount)
     if (currentDirection == "center") {
       // Center direction tends to look stronger; scale it down for parity with iOS
       radius *= 0.35f
     }
     currentBlurRadius = radius
-    logDebug("setBlurAmount: $amount -> $currentBlurRadius (direction=$currentDirection)")
+    logDebug("applyBlurRadius: amount=$currentBlurAmount -> $currentBlurRadius (direction=$currentDirection)")
 
     try {
       blurView?.setBlurRadius(currentBlurRadius)
@@ -494,6 +513,8 @@ class ReactNativeProgressiveBlurView : FrameLayout {
     logDebug("setDirection: $direction -> $currentDirection")
 
     try {
+      // Recompute the radius: switching to/from center changes the scale factor.
+      applyBlurRadius()
       updateGradient()
     } catch (e: Exception) {
       logError("Failed to set gradient direction: ${e.message}", e)


### PR DESCRIPTION
Part 1 of 6 in the July 2026 audit remediation (see `docs/audit-2026-07.md`). **Stacked on `main`.**

Android correctness, including the one Critical finding.

- **AND-NEW-1 (Critical)**: BlurSwitch tore down its listeners in `onDetachedFromWindow`, so after react-navigation detach/re-attach (or FlatList cell clipping) it stopped reporting toggles. Teardown now runs only from `onDropViewInstance`.
- BlurView defers its root-swap + init to a posted runnable (mirroring ProgressiveBlurView) so re-attach under navigation reliably re-establishes the Screen-scoped blur root.
- AND-08 explicit per-corner radius 0; AND-NEW-2 order-independent centre scaling; AND-NEW-4 clamp centre gradient stops; AND-NEW-5 refresh on invalid tint; AND-NEW-3 dead-code removal.
- **AND-02**: ships `consumer-rules.pro` so a consumer's R8 build doesn't strip the reflected QmBlurView fields and silently regress to whole-screen blur (#89).

Verified on an Android emulator: toggle works, survives navigation, and state persists across a second navigation; no exceptions in logcat.