### PR TITLE
fix(ios): liquid-glass accessibility, tint, corners, child mount (audit PR 2/6)

### DIFF
--- a/ios/ReactNativeLiquidGlassContainer.mm
+++ b/ios/ReactNativeLiquidGlassContainer.mm
@@ -72,13 +72,13 @@ using namespace facebook::react;
     const auto &props = *std::static_pointer_cast<ReactNativeLiquidGlassContainerProps const>(_props);
     const auto borderMetrics = props.resolveBorderMetrics(_layoutMetrics);
 
-    // Use topLeft.horizontal same as React Native RCTViewComponentView implementation
+    // Use topLeft.horizontal same as React Native RCTViewComponentView
+    // implementation. Applied unconditionally so a radius of 0 clears any stale
+    // rounding rather than leaving it from a previous mount.
     CGFloat radius = borderMetrics.borderRadii.topLeft.horizontal;
 
-    if (radius > 0) {
-      _containerView.layer.cornerRadius = radius;
-      _containerView.layer.masksToBounds = YES;
-    }
+    _containerView.layer.cornerRadius = radius;
+    _containerView.layer.masksToBounds = radius > 0;
   }
 }
 
@@ -101,16 +101,19 @@ using namespace facebook::react;
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  if (@available(iOS 26.0, *)) {
-    // On iOS 26+, add children to the contentView if available
-    if ([_containerView isKindOfClass:[UIVisualEffectView class]]) {
-      UIVisualEffectView *effectView = (UIVisualEffectView *)_containerView;
-      [effectView.contentView insertSubview:childComponentView atIndex:index];
-      return;
-    }
+  // Route children into contentView whenever the container actually is a
+  // UIVisualEffectView, decided by the runtime class rather than the OS
+  // version. Built with Xcode 26, the Swift LiquidGlassContainer is a
+  // UIVisualEffectView even on iOS < 26 (its effect just stays nil there), and
+  // adding subviews straight to a UIVisualEffectView is forbidden by UIKit and
+  // throws — contentView is always the correct target for one.
+  if ([_containerView isKindOfClass:[UIVisualEffectView class]]) {
+    UIVisualEffectView *effectView = (UIVisualEffectView *)_containerView;
+    [effectView.contentView insertSubview:childComponentView atIndex:index];
+    return;
   }
 
-  // Fallback: add directly to container view
+  // Fallback: pre-Xcode-26 builds where LiquidGlassContainer is a plain UIView.
   [_containerView insertSubview:childComponentView atIndex:index];
 }
 

--- a/ios/ReactNativeLiquidGlassView.mm
+++ b/ios/ReactNativeLiquidGlassView.mm
@@ -190,13 +190,13 @@ using namespace facebook::react;
   const auto &oldViewProps = *std::static_pointer_cast<ReactNativeLiquidGlassViewProps const>(_props);
   const auto &newViewProps = *std::static_pointer_cast<ReactNativeLiquidGlassViewProps const>(props);
 
-  // Update glassTintColor if it has changed
+  // Update glassTintColor if it has changed. Apply even for an empty string:
+  // colorFromString maps "" to clear, and the view treats a zero-alpha tint as
+  // "no tint", so clearing a previously-set tint actually takes effect.
   if (oldViewProps.glassTintColor != newViewProps.glassTintColor) {
-    if (!newViewProps.glassTintColor.empty()) {
-      NSString *glassTintColorString = [[NSString alloc] initWithUTF8String:newViewProps.glassTintColor.c_str()];
-      UIColor *newGlassTintColor = [ReactNativeLiquidGlassView colorFromString:glassTintColorString];
-      [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withGlassTintColor:newGlassTintColor];
-    }
+    NSString *glassTintColorString = [[NSString alloc] initWithUTF8String:newViewProps.glassTintColor.c_str()];
+    UIColor *newGlassTintColor = [ReactNativeLiquidGlassView colorFromString:glassTintColorString];
+    [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withGlassTintColor:newGlassTintColor];
   }
 
   // Update glassOpacity if it has changed
@@ -223,13 +223,13 @@ using namespace facebook::react;
     [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withIgnoringSafeArea:newViewProps.ignoreSafeArea];
   }
 
-  // Update reducedTransparencyFallbackColor if it has changed
+  // Update reducedTransparencyFallbackColor if it has changed. Apply even when
+  // empty so clearing the prop resets to the parsed default rather than
+  // stranding the previous colour.
   if (oldViewProps.reducedTransparencyFallbackColor != newViewProps.reducedTransparencyFallbackColor) {
-    if (!newViewProps.reducedTransparencyFallbackColor.empty()) {
-      NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:newViewProps.reducedTransparencyFallbackColor.c_str()];
-      UIColor *fallbackColor = [ReactNativeLiquidGlassView colorFromString:fallbackColorString];
-      [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withReducedTransparencyFallbackColor:fallbackColor];
-    }
+    NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:newViewProps.reducedTransparencyFallbackColor.c_str()];
+    UIColor *fallbackColor = [ReactNativeLiquidGlassView colorFromString:fallbackColorString];
+    [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withReducedTransparencyFallbackColor:fallbackColor];
   }
 
   // Store the new props
@@ -274,17 +274,18 @@ using namespace facebook::react;
 {
   [super finalizeUpdates:updateMask];
 
-  // Apply border radius from layout metrics to the inner glass view (Callstack pattern)
+  // Apply per-corner border radius from layout metrics to the inner glass view.
+  // Applied unconditionally (including 0) so animating a radius down to 0 or
+  // recycling a rounded view into an unrounded mount actually squares the
+  // corners instead of keeping the stale radius.
   if (@available(iOS 26.0, *)) {
     const auto &props = *std::static_pointer_cast<ReactNativeLiquidGlassViewProps const>(_props);
     const auto borderMetrics = props.resolveBorderMetrics(_layoutMetrics);
 
-    // Use topLeft.horizontal same as React Native RCTViewComponentView implementation
-    CGFloat radius = borderMetrics.borderRadii.topLeft.horizontal;
-
-    if (radius > 0) {
-      [_liquidGlassView setBorderRadius:radius];
-    }
+    [_liquidGlassView setBorderRadiiWithTopLeft:borderMetrics.borderRadii.topLeft.horizontal
+                                       topRight:borderMetrics.borderRadii.topRight.horizontal
+                                     bottomLeft:borderMetrics.borderRadii.bottomLeft.horizontal
+                                    bottomRight:borderMetrics.borderRadii.bottomRight.horizontal];
   }
 }
 

--- a/ios/Views/LiquidGlassContainerView.swift
+++ b/ios/Views/LiquidGlassContainerView.swift
@@ -37,31 +37,37 @@ import UIKit
     }
   }
 
+  // false confines the glass to the safe area; true (the JS-side default) lets
+  // it fill the whole view. Applied in layoutSubviews.
   @objc public var ignoreSafeArea: Bool = false {
     didSet {
-      // Not used in UIKit approach
+      if ignoreSafeArea != oldValue {
+        setNeedsLayout()
+      }
     }
   }
 
-  // Border radius storage for React Native's style system
+  // Per-corner radii in points. The iOS 26 path applies all four via
+  // cornerConfiguration; the pre-26 / reduced-transparency fallback can only
+  // render a uniform CALayer cornerRadius, so it uses topLeftRadius.
   private var topLeftRadius: CGFloat = 0
   private var topRightRadius: CGFloat = 0
   private var bottomLeftRadius: CGFloat = 0
   private var bottomRightRadius: CGFloat = 0
-  private var allBorderRadius: CGFloat = 0
 
   private var foregroundObserver: NSObjectProtocol?
+  private var reduceTransparencyObserver: NSObjectProtocol?
 
   public override init(frame: CGRect) {
     super.init(frame: frame)
     setupView()
-    registerForegroundObserver()
+    registerObservers()
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     setupView()
-    registerForegroundObserver()
+    registerObservers()
   }
 
   // The glass/blur effect is assigned to the UIVisualEffectView once. UIKit
@@ -76,9 +82,20 @@ import UIKit
     }
   }
 
-  private func registerForegroundObserver() {
+  private func registerObservers() {
     foregroundObserver = NotificationCenter.default.addObserver(
       forName: UIApplication.willEnterForegroundNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.updateEffect()
+    }
+
+    // Re-evaluate the glass/fallback state when the user toggles Reduce
+    // Transparency while the view is mounted, so the accessibility fallback
+    // takes effect immediately instead of only on the next prop change.
+    reduceTransparencyObserver = NotificationCenter.default.addObserver(
+      forName: UIAccessibility.reduceTransparencyStatusDidChangeNotification,
       object: nil,
       queue: .main
     ) { [weak self] _ in
@@ -90,51 +107,71 @@ import UIKit
     if let foregroundObserver {
       NotificationCenter.default.removeObserver(foregroundObserver)
     }
+    if let reduceTransparencyObserver {
+      NotificationCenter.default.removeObserver(reduceTransparencyObserver)
+    }
   }
 
   private func setupView() {
     let effectView = UIVisualEffectView()
     effectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     effectView.frame = bounds
-    
+
     // Don't clip bounds to allow interactive glass animations to be visible
     effectView.clipsToBounds = false
-    
+
     addSubview(effectView)
     self.glassEffectView = effectView
-    
+
     updateEffect()
   }
 
   // MARK: - Border Radius Methods (called by React Native's style system)
-  
+
   @objc public func setBorderRadius(_ radius: CGFloat) {
-    allBorderRadius = radius
+    setBorderRadii(topLeft: radius, topRight: radius, bottomLeft: radius, bottomRight: radius)
+  }
+
+  @objc public func setBorderRadii(topLeft: CGFloat, topRight: CGFloat, bottomLeft: CGFloat, bottomRight: CGFloat) {
+    topLeftRadius = topLeft
+    topRightRadius = topRight
+    bottomLeftRadius = bottomLeft
+    bottomRightRadius = bottomRight
     updateBorderRadius()
   }
 
   private func updateEffect() {
+    // Honor Reduce Transparency on every path, including the iOS 26 glass API,
+    // which otherwise renders full glass and leaves reducedTransparencyFallbackColor
+    // dead (the accessibility setting was never observed either).
+    if UIAccessibility.isReduceTransparencyEnabled {
+      updateFallback()
+      return
+    }
+
     // Check if we can use the new API (iOS 26+)
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2)
       let style: UIGlassEffect.Style = glassType == "regular" ? .regular : .clear
-      
+
       // Always create a new effect to ensure proper rendering
       let effect = UIGlassEffect(style: style)
-      // A zero-alpha tint means "no tint". Running it through
-      // withAlphaComponent(glassOpacity) resurrects UIColor.clear (black at
-      // alpha 0) as opaque black (issue #113) — leave the glass untinted.
-      if glassTintColor.cgColor.alpha == 0 {
+      // A zero-alpha tint means "no tint": running UIColor.clear (black at
+      // alpha 0) through withAlphaComponent would resurrect it as opaque black
+      // (issue #113). Otherwise multiply the tint's own alpha by glassOpacity
+      // instead of replacing it, so a semi-transparent tint stays semi-transparent.
+      let tintAlpha = glassTintColor.cgColor.alpha
+      if tintAlpha == 0 {
         effect.tintColor = nil
       } else {
-        effect.tintColor = glassTintColor.withAlphaComponent(glassOpacity)
+        effect.tintColor = glassTintColor.withAlphaComponent(tintAlpha * glassOpacity)
       }
       effect.isInteractive = isInteractive
-      
+
       glassEffectView?.effect = effect
       glassEffect = effect
       currentGlassStyle = glassType
-      
+
       updateBorderRadius()
       #else
       // Fallback for older compilers (Xcode < 16.x) even on newer iOS
@@ -169,39 +206,42 @@ import UIKit
       glassEffectView?.contentView.backgroundColor = .clear
     }
 
-    layer.cornerRadius = allBorderRadius
-    glassEffectView?.layer.cornerRadius = allBorderRadius
+    // Fallback layers can only render a uniform corner radius.
+    layer.cornerRadius = topLeftRadius
+    glassEffectView?.layer.cornerRadius = topLeftRadius
     glassEffectView?.layer.masksToBounds = true
   }
 
   private func updateBorderRadius() {
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2)
-      let topLeft = UICornerRadius(floatLiteral: Double(allBorderRadius))
-      let topRight = UICornerRadius(floatLiteral: Double(allBorderRadius))
-      let bottomLeft = UICornerRadius(floatLiteral: Double(allBorderRadius))
-      let bottomRight = UICornerRadius(floatLiteral: Double(allBorderRadius))
-      
       glassEffectView?.cornerConfiguration = .corners(
-        topLeftRadius: topLeft,
-        topRightRadius: topRight,
-        bottomLeftRadius: bottomLeft,
-        bottomRightRadius: bottomRight
+        topLeftRadius: UICornerRadius(floatLiteral: Double(topLeftRadius)),
+        topRightRadius: UICornerRadius(floatLiteral: Double(topRightRadius)),
+        bottomLeftRadius: UICornerRadius(floatLiteral: Double(bottomLeftRadius)),
+        bottomRightRadius: UICornerRadius(floatLiteral: Double(bottomRightRadius))
       )
       #else
-      layer.cornerRadius = allBorderRadius
+      layer.cornerRadius = topLeftRadius
       layer.masksToBounds = true
       #endif
     } else {
-      layer.cornerRadius = allBorderRadius
+      layer.cornerRadius = topLeftRadius
     }
   }
 
   public override func layoutSubviews() {
     super.layoutSubviews()
-    glassEffectView?.frame = bounds
+    // ignoreSafeArea == false confines the glass to the safe area; true (the
+    // JS-side default) lets it fill the whole view.
+    glassEffectView?.frame = ignoreSafeArea ? bounds : bounds.inset(by: safeAreaInsets)
   }
-  
+
+  public override func safeAreaInsetsDidChange() {
+    super.safeAreaInsetsDidChange()
+    setNeedsLayout()
+  }
+
   // For child view mounting
   @objc public func getContentView() -> UIView? {
     if #available(iOS 26.0, *) {


### PR DESCRIPTION
Part 2 of 6 in the July 2026 audit remediation. **Stacked on `fix/android-pr1-lifecycle-correctness`.**

iOS liquid-glass correctness.

- **IOS-03** honor Reduce Transparency on the iOS 26 glass path + status observer.
- **IOS-13** multiply the tint's own alpha by `glassOpacity` instead of replacing it (keeps the #113 zero-alpha guard).
- **IOS-12 / IOS-02** apply all four corner radii via `cornerConfiguration`, unconditionally (radius 0 squares corners).
- **IOS-05** implement `ignoreSafeArea`; **IOS-04** apply colour props even when empty.
- **IOS-NEW-2** container mounts children by runtime class, fixing a UIKit exception on iOS 18-25 with Xcode 26.

Verified on an iOS 26 simulator: glass renders rounded + translucent (blue then purple at 80%), container mounts children, tint updates live, no redbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale corner rounding when border radii are reduced, cleared, or changed independently.
  - Ensured glass tint and transparency fallback colors reset correctly when removed.
  - Improved handling of safe-area changes and the “Ignore Safe Area” setting.
  - Updated glass rendering to respond immediately when Reduce Transparency is enabled.

- **Improvements**
  - Improved iOS 26 glass styling, including per-corner radii and opacity-aware tinting.
  - Enhanced rendering consistency across supported iOS versions and container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->