### PR TITLE
fix(ios): self-healing, animator contract, recycle, effect coalescing (audit PR 3/6)

### DIFF
--- a/ios/ReactNativeBlurView.mm
+++ b/ios/ReactNativeBlurView.mm
@@ -194,13 +194,13 @@ using namespace facebook::react;
     [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withBlurType:blurTypeString];
   }
 
-  // Update reducedTransparencyFallbackColor if it has changed
+  // Update reducedTransparencyFallbackColor if it has changed. Apply even when
+  // empty so clearing the prop resets rather than stranding the old colour
+  // (this conditional-skip was the recycling-staleness vector for this view).
   if (oldViewProps.reducedTransparencyFallbackColor != newViewProps.reducedTransparencyFallbackColor) {
-    if (!newViewProps.reducedTransparencyFallbackColor.empty()) {
-      NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:newViewProps.reducedTransparencyFallbackColor.c_str()];
-      UIColor *fallbackColor = [ReactNativeBlurView colorFromString:fallbackColorString];
-      [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withReducedTransparencyFallbackColor:fallbackColor];
-    }
+    NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:newViewProps.reducedTransparencyFallbackColor.c_str()];
+    UIColor *fallbackColor = [ReactNativeBlurView colorFromString:fallbackColorString];
+    [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withReducedTransparencyFallbackColor:fallbackColor];
   }
 
   // Update ignoreSafeArea if it has changed
@@ -212,6 +212,30 @@ using namespace facebook::react;
   _props = props;
 
   [super updateProps:props oldProps:oldProps];
+}
+
+// Fabric recycles component views. Reset cached props and the inner view's
+// visual state to defaults so no blur amount/type/fallback/safe-area setting
+// leaks into the next mount.
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+
+  static const auto defaultProps = std::make_shared<const ReactNativeBlurViewProps>();
+  _props = defaultProps;
+
+  const auto &bvProps = *std::static_pointer_cast<const ReactNativeBlurViewProps>(defaultProps);
+
+  [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withBlurAmount:bvProps.blurAmount];
+
+  NSString *blurTypeString = [[NSString alloc] initWithUTF8String:toString(bvProps.blurType).c_str()];
+  [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withBlurType:blurTypeString];
+
+  NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:bvProps.reducedTransparencyFallbackColor.c_str()];
+  UIColor *fallbackColor = [ReactNativeBlurView colorFromString:fallbackColorString];
+  [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withReducedTransparencyFallbackColor:fallbackColor];
+
+  [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withIgnoringSafeArea:bvProps.ignoreSafeArea];
 }
 
 - (void)layoutSubviews

--- a/ios/ReactNativeLiquidGlassView.mm
+++ b/ios/ReactNativeLiquidGlassView.mm
@@ -153,6 +153,9 @@ using namespace facebook::react;
 
     _liquidGlassView = [ReactNativeLiquidGlassViewHelper createLiquidGlassViewWithFrame:frame];
 
+    // Coalesce the initial prop setters into a single effect rebuild.
+    [_liquidGlassView beginBatchUpdate];
+
     // Set initial glassTintColor from default props
     NSString *defaultGlassTintColorString = [[NSString alloc] initWithUTF8String:lgProps.glassTintColor.c_str()];
     UIColor *defaultGlassTintColor = [ReactNativeLiquidGlassView colorFromString:defaultGlassTintColorString];
@@ -180,6 +183,8 @@ using namespace facebook::react;
       [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withReducedTransparencyFallbackColor:fallbackColor];
     }
 
+    [_liquidGlassView endBatchUpdate];
+
     [self addSubview:_liquidGlassView];
   }
   return self;
@@ -189,6 +194,9 @@ using namespace facebook::react;
 {
   const auto &oldViewProps = *std::static_pointer_cast<ReactNativeLiquidGlassViewProps const>(_props);
   const auto &newViewProps = *std::static_pointer_cast<ReactNativeLiquidGlassViewProps const>(props);
+
+  // Coalesce the individual prop setters below into a single effect rebuild.
+  [_liquidGlassView beginBatchUpdate];
 
   // Update glassTintColor if it has changed. Apply even for an empty string:
   // colorFromString maps "" to clear, and the view treats a zero-alpha tint as
@@ -231,6 +239,9 @@ using namespace facebook::react;
     UIColor *fallbackColor = [ReactNativeLiquidGlassView colorFromString:fallbackColorString];
     [ReactNativeLiquidGlassViewHelper updateLiquidGlassView:_liquidGlassView withReducedTransparencyFallbackColor:fallbackColor];
   }
+
+  // Apply all of the above in one effect rebuild.
+  [_liquidGlassView endBatchUpdate];
 
   // Store the new props
   _props = props;

--- a/ios/ReactNativeProgressiveBlurView.mm
+++ b/ios/ReactNativeProgressiveBlurView.mm
@@ -196,16 +196,42 @@ using namespace facebook::react;
     [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withStartOffset:newViewProps.startOffset];
   }
 
+  // Apply even when empty so clearing the prop resets rather than stranding the
+  // old colour (the conditional-skip was this view's recycling-staleness vector).
   if (oldViewProps.reducedTransparencyFallbackColor != newViewProps.reducedTransparencyFallbackColor) {
-    if (!newViewProps.reducedTransparencyFallbackColor.empty()) {
-      NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:newViewProps.reducedTransparencyFallbackColor.c_str()];
-      UIColor *fallbackColor = [ReactNativeProgressiveBlurView colorFromString:fallbackColorString];
-      [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withReducedTransparencyFallbackColor:fallbackColor];
-    }
+    NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:newViewProps.reducedTransparencyFallbackColor.c_str()];
+    UIColor *fallbackColor = [ReactNativeProgressiveBlurView colorFromString:fallbackColorString];
+    [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withReducedTransparencyFallbackColor:fallbackColor];
   }
 
   _props = props;
   [super updateProps:props oldProps:oldProps];
+}
+
+// Fabric recycles component views. Reset cached props and the inner view's
+// visual state to defaults so no blur setting leaks into the next mount.
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+
+  static const auto defaultProps = std::make_shared<const ReactNativeProgressiveBlurViewProps>();
+  _props = defaultProps;
+
+  const auto &pbvProps = *std::static_pointer_cast<const ReactNativeProgressiveBlurViewProps>(defaultProps);
+
+  [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withBlurAmount:pbvProps.blurAmount];
+
+  NSString *blurTypeString = [[NSString alloc] initWithUTF8String:toString(pbvProps.blurType).c_str()];
+  [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withBlurType:blurTypeString];
+
+  NSString *directionString = [[NSString alloc] initWithUTF8String:toString(pbvProps.direction).c_str()];
+  [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withDirection:directionString];
+
+  [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withStartOffset:pbvProps.startOffset];
+
+  NSString *fallbackColorString = [[NSString alloc] initWithUTF8String:pbvProps.reducedTransparencyFallbackColor.c_str()];
+  UIColor *fallbackColor = [ReactNativeProgressiveBlurView colorFromString:fallbackColorString];
+  [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withReducedTransparencyFallbackColor:fallbackColor];
 }
 
 - (void)layoutSubviews

--- a/ios/ReactNativeVibrancyView.mm
+++ b/ios/ReactNativeVibrancyView.mm
@@ -67,6 +67,21 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+// Fabric recycles component views. Reset cached props and the inner view's
+// visual state to defaults so no blur type/amount leaks into the next mount.
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+
+  static const auto defaultProps = std::make_shared<const ReactNativeVibrancyViewProps>();
+  _props = defaultProps;
+
+  const auto &props = *std::static_pointer_cast<const ReactNativeVibrancyViewProps>(defaultProps);
+  NSString *blurType = [[NSString alloc] initWithUTF8String:toString(props.blurType).c_str()];
+  [ReactNativeVibrancyViewHelper updateVibrancyView:_vibrancyView withBlurType:blurType];
+  [ReactNativeVibrancyViewHelper updateVibrancyView:_vibrancyView withBlurAmount:props.blurAmount];
+}
+
 - (void)layoutSubviews
 {
   [super layoutSubviews];
@@ -82,6 +97,12 @@ using namespace facebook::react;
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
     [childComponentView removeFromSuperview];
+}
+
+- (void)dealloc
+{
+  [_vibrancyView removeFromSuperview];
+  _vibrancyView = nil;
 }
 
 @end

--- a/ios/Views/LiquidGlassContainer.swift
+++ b/ios/Views/LiquidGlassContainer.swift
@@ -6,7 +6,7 @@ import UIKit
 @objc public class LiquidGlassContainer: UIVisualEffectView {
   @objc public var spacing: CGFloat = 0 {
     didSet {
-      if #available(iOS 26.0, *) {
+      if spacing != oldValue, #available(iOS 26.0, *) {
         setupView()
       }
     }
@@ -15,7 +15,13 @@ import UIKit
   public override func layoutSubviews() {
     super.layoutSubviews()
     if #available(iOS 26.0, *) {
-      setupView()
+      // Only (re)build the container effect when it is missing. UIKit can drop
+      // it across transitions/backgrounding, and a layout pass runs on window
+      // re-entry, so this self-heals. Rebuilding on every layout pass instead
+      // restarted the glass-merge animation each frame (perf churn).
+      if effect == nil {
+        setupView()
+      }
     }
   }
 

--- a/ios/Views/LiquidGlassContainerView.swift
+++ b/ios/Views/LiquidGlassContainerView.swift
@@ -58,6 +58,11 @@ import UIKit
   private var foregroundObserver: NSObjectProtocol?
   private var reduceTransparencyObserver: NSObjectProtocol?
 
+  // While true, prop setters skip rebuilding the effect. The Fabric layer wraps
+  // a single updateProps commit in beginBatchUpdate/endBatchUpdate so several
+  // changed props rebuild the UIGlassEffect once instead of once per property.
+  private var isBatchingUpdates = false
+
   public override init(frame: CGRect) {
     super.init(frame: frame)
     setupView()
@@ -140,7 +145,20 @@ import UIKit
     updateBorderRadius()
   }
 
+  // MARK: - Batched prop updates
+
+  @objc public func beginBatchUpdate() {
+    isBatchingUpdates = true
+  }
+
+  @objc public func endBatchUpdate() {
+    isBatchingUpdates = false
+    updateEffect()
+  }
+
   private func updateEffect() {
+    if isBatchingUpdates { return }
+
     // Honor Reduce Transparency on every path, including the iOS 26 glass API,
     // which otherwise renders full glass and leaves reducedTransparencyFallbackColor
     // dead (the accessibility setting was never observed either).
@@ -184,6 +202,8 @@ import UIKit
   }
 
   private func updateFallback() {
+    if isBatchingUpdates { return }
+
     if UIAccessibility.isReduceTransparencyEnabled {
       backgroundColor = reducedTransparencyFallbackColor
       glassEffectView?.effect = nil

--- a/ios/Views/VibrancyEffectView.swift
+++ b/ios/Views/VibrancyEffectView.swift
@@ -5,6 +5,7 @@ import UIKit
   private let blurEffectView = UIVisualEffectView()
   private let vibrancyEffectView = UIVisualEffectView()
   private var blurAnimator: UIViewPropertyAnimator?
+  private var foregroundObserver: NSObjectProtocol?
 
   @objc public var blurType: String = "xlight" {
     didSet {
@@ -25,18 +26,21 @@ import UIKit
   public override init(frame: CGRect) {
     super.init(frame: frame)
     setupViews()
+    registerForegroundObserver()
     updateEffect()
   }
 
   public init(effect: UIVisualEffect?) {
     super.init(frame: .zero)
     setupViews()
+    registerForegroundObserver()
     updateEffect()
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     setupViews()
+    registerForegroundObserver()
     updateEffect()
   }
 
@@ -52,13 +56,34 @@ import UIKit
     blurEffectView.contentView.addSubview(vibrancyEffectView)
   }
 
+  // The vibrancy intensity is baked with a UIViewPropertyAnimator. UIKit resets
+  // the effect views' state across background/foreground cycles and can flush a
+  // baked animator during transitions, leaving the vibrancy at full intensity.
+  // Rebuild whenever the view (re-)enters a window and on foreground so the
+  // intensity is restored, matching BlurEffectView.
+  public override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      updateEffect()
+    }
+  }
+
+  private func registerForegroundObserver() {
+    foregroundObserver = NotificationCenter.default.addObserver(
+      forName: UIApplication.willEnterForegroundNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.updateEffect()
+    }
+  }
+
   private func updateEffect() {
     let interfaceStyle = interfaceStyleForBlurType(blurType) ?? .unspecified
     overrideUserInterfaceStyle = interfaceStyle
 
     if let animator = blurAnimator {
-      animator.stopAnimation(true)
-      animator.finishAnimation(at: .current)
+      finalizeAnimator(animator)
     }
     blurAnimator = nil
 
@@ -71,29 +96,45 @@ import UIKit
 
     blurEffectView.effect = blurEffect
     vibrancyEffectView.effect = vibrancyEffect
-    
-    blurAnimator = UIViewPropertyAnimator(duration: 1, curve: .linear) { [weak self] in
-        self?.blurEffectView.effect = nil
-        self?.vibrancyEffectView.effect = nil
+
+    let animator = UIViewPropertyAnimator(duration: 1, curve: .linear) { [weak self] in
+      self?.blurEffectView.effect = nil
+      self?.vibrancyEffectView.effect = nil
     }
+    blurAnimator = animator
 
     let intensity = min(max(blurAmount / 100.0, 0.0), 1.0)
-    blurAnimator?.fractionComplete = 1.0 - intensity
+    animator.fractionComplete = 1.0 - intensity
 
-    DispatchQueue.main.async { [weak self, weak blurAnimator] in
-        guard let self = self, let currentAnimator = self.blurAnimator, currentAnimator === blurAnimator else { return }
-        
-        currentAnimator.stopAnimation(true)
-        currentAnimator.finishAnimation(at: .current)
+    DispatchQueue.main.async { [weak self, weak animator] in
+      guard let self = self, let currentAnimator = animator, self.blurAnimator === currentAnimator else { return }
+      self.finalizeAnimator(currentAnimator)
+    }
+  }
+
+  // Move the animator to .inactive without violating the UIViewPropertyAnimator
+  // state machine: stopAnimation(true) followed by finishAnimation(at:) throws,
+  // because finishAnimation is only valid on a stopped animator. Stop it if
+  // running, then finish it if stopped, so the effect is baked at its current
+  // fraction with no exception.
+  private func finalizeAnimator(_ animator: UIViewPropertyAnimator) {
+    if animator.state == .active {
+      animator.stopAnimation(false)
+    }
+    if animator.state == .stopped {
+      animator.finishAnimation(at: .current)
     }
   }
 
   deinit {
-    guard let animator = blurAnimator, animator.state == .active else { return }
-    animator.stopAnimation(true)
-    animator.finishAnimation(at: .current)
+    if let animator = blurAnimator {
+      finalizeAnimator(animator)
+    }
+    if let foregroundObserver {
+      NotificationCenter.default.removeObserver(foregroundObserver)
+    }
   }
-    
+
     // Helper to parse string to UIBlurEffect.Style
     private func styleFromString(_ style: String) -> UIBlurEffect.Style {
         switch style {


### PR DESCRIPTION
Part 3 of 6 in the July 2026 audit remediation. **Stacked on `fix/ios-pr2-glass-correctness`.**

iOS lifecycle robustness and effect-churn.

- **IOS-08** VibrancyView self-healing (didMoveToWindow + foreground) + missing dealloc.
- **IOS-NEW-3** fix the `stopAnimation(true)` + `finishAnimation` contract violation (state-guarded finalize).
- **IOS-06** stop rebuilding the container effect every layout pass; coalesce the single glass view's per-prop rebuilds into one per commit.
- **IOS-07** container self-heals via rebuild-if-missing; **IOS-01** prepareForRecycle on Blur/Progressive/Vibrancy + drop the empty-string colour skip.

Verified on an iOS 26 simulator: vibrancy renders at all intensities and survives repeated navigate-away-and-back with no animator exception; glass batched updates render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale transparency fallback colors when the setting is cleared.
  - Prevented blur, vibrancy, and liquid glass settings from carrying over when views are recycled.
  - Improved cleanup of vibrancy effects during view destruction.
  - Restored vibrancy effects when views return to the screen or app foreground.

- **Performance**
  - Reduced unnecessary liquid glass effect rebuilds during layout and property updates.
  - Batched multiple visual updates into a single effect refresh for smoother rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->