### PR TITLE
fix: align codegen contract across native and JS (audit PR 4/6)

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitch.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitch.kt
@@ -31,7 +31,11 @@ class ReactNativeBlurSwitch : BlurSwitchButtonView {
     private const val DEFAULT_HEIGHT_DP = 36f
     private const val MIN_BLUR_AMOUNT = 0f
     private const val MAX_BLUR_AMOUNT = 100f
-    private const val MAX_BLUR_RADIUS = 25f
+    // Kept equal to MAX_BLUR_AMOUNT so blurAmount maps 1:1 to the QmBlurView
+    // radius, matching ReactNativeBlurView and ReactNativeProgressiveBlurView.
+    // (The switch previously used 25f, making the same blurAmount render a
+    // weaker blur than the other components.)
+    private const val MAX_BLUR_RADIUS = 100f
     private const val DEBUG = false
 
     private fun logDebug(message: String) {
@@ -49,9 +53,10 @@ class ReactNativeBlurSwitch : BlurSwitchButtonView {
     }
 
     /**
-     * Maps blur amount (0-100) to blur radius (0-25).
+     * Maps blur amount (0-100) 1:1 to the QmBlurView blur radius, matching the
+     * other blur components.
      * @param amount The blur amount from 0-100
-     * @return The corresponding blur radius from 0-25
+     * @return The corresponding blur radius
      */
     private fun mapBlurAmountToRadius(amount: Float): Float {
       val clampedAmount = amount.coerceIn(MIN_BLUR_AMOUNT, MAX_BLUR_AMOUNT)

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitchManager.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitchManager.kt
@@ -1,17 +1,27 @@
 package com.sbaiahmed1.reactnativeblur
 
-import android.graphics.Color
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.events.RCTEventEmitter
+import com.facebook.react.viewmanagers.ReactNativeBlurSwitchManagerInterface
+import com.facebook.react.viewmanagers.ReactNativeBlurSwitchManagerDelegate
 import androidx.core.graphics.toColorInt
 
 @ReactModule(name = ReactNativeBlurSwitchManager.NAME)
-class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>() {
+class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>(),
+  ReactNativeBlurSwitchManagerInterface<ReactNativeBlurSwitch> {
+
+  private val mDelegate: ViewManagerDelegate<ReactNativeBlurSwitch> =
+    ReactNativeBlurSwitchManagerDelegate(this)
+
+  override fun getDelegate(): ViewManagerDelegate<ReactNativeBlurSwitch> {
+    return mDelegate
+  }
 
   override fun getName(): String {
     return NAME
@@ -31,22 +41,22 @@ class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>() 
   }
 
   @ReactProp(name = "value")
-  fun setValue(view: ReactNativeBlurSwitch?, value: Boolean) {
+  override fun setValue(view: ReactNativeBlurSwitch?, value: Boolean) {
     view?.setValue(value)
   }
 
-  @ReactProp(name = "blurAmount", defaultDouble = 10.0)
-  fun setBlurAmount(view: ReactNativeBlurSwitch?, blurAmount: Double) {
+  @ReactProp(name = "blurAmount")
+  override fun setBlurAmount(view: ReactNativeBlurSwitch?, blurAmount: Double) {
     view?.setBlurAmount(blurAmount.toFloat())
   }
 
   @ReactProp(name = "blurRounds")
-  fun setBlurRounds(view: ReactNativeBlurSwitch?, blurRounds: Int) {
+  override fun setBlurRounds(view: ReactNativeBlurSwitch?, blurRounds: Int) {
     view?.setRounds(blurRounds)
   }
 
   @ReactProp(name = "thumbColor")
-  fun setThumbColor(view: ReactNativeBlurSwitch?, color: String?) {
+  override fun setThumbColor(view: ReactNativeBlurSwitch?, color: String?) {
     color?.let {
       try {
         view?.setThumbColor(it.toColorInt())
@@ -57,7 +67,7 @@ class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>() 
   }
 
   @ReactProp(name = "trackColorOff")
-  fun setTrackColorOff(view: ReactNativeBlurSwitch?, color: String?) {
+  override fun setTrackColorOff(view: ReactNativeBlurSwitch?, color: String?) {
     color?.let {
       try {
         view?.setTrackColorOff(it.toColorInt())
@@ -68,18 +78,18 @@ class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>() 
   }
 
   @ReactProp(name = "trackColorOn")
-  fun setTrackColorOn(view: ReactNativeBlurSwitch?, color: String?) {
+  override fun setTrackColorOn(view: ReactNativeBlurSwitch?, color: String?) {
     color?.let {
-     try {
-       view?.setTrackColorOn(it.toColorInt())
-     } catch (e: Exception) {
-       android.util.Log.w("ReactNativeBlurSwitchManager", "Invalid trackColorOn: $color", e)
-     }
+      try {
+        view?.setTrackColorOn(it.toColorInt())
+      } catch (e: Exception) {
+        android.util.Log.w("ReactNativeBlurSwitchManager", "Invalid trackColorOn: $color", e)
+      }
     }
   }
 
   @ReactProp(name = "disabled")
-  fun setDisabled(view: ReactNativeBlurSwitch?, disabled: Boolean) {
+  override fun setDisabled(view: ReactNativeBlurSwitch?, disabled: Boolean) {
     view?.setDisabled(disabled)
   }
 
@@ -88,7 +98,7 @@ class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>() 
    */
   override fun onDropViewInstance(view: ReactNativeBlurSwitch) {
     super.onDropViewInstance(view)
-    // Call cleanup to reset state and prevent white screen artifacts
+    // Reset state and drop listeners now that React Native is done with the view.
     view.cleanup()
   }
 
@@ -102,4 +112,3 @@ class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>() 
     const val NAME = "ReactNativeBlurSwitch"
   }
 }
-

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -51,10 +51,12 @@ class ReactNativeBlurView : BlurViewGroup {
     private const val MAX_BLUR_RADIUS = 100f
     private const val DEFAULT_BLUR_RADIUS = 10f
     // Number of native box-blur passes. Each round is a full pass over the
-    // downsampled capture bitmap, so this is a direct CPU cost multiplier.
-    // At the current downsample factor 3 passes are visually indistinguishable
-    // from 5 while cutting blur work by ~40%.
-    private const val DEFAULT_BLUR_ROUNDS = 3
+    // downsampled capture bitmap, so it is a direct CPU cost multiplier. Kept
+    // at 5 to match the JS wrapper and codegen default (one source of truth):
+    // the wrapper always sends blurRounds, so a lower internal default was
+    // never reachable. Fewer passes trade a little quality for less blur work
+    // if a consumer lowers the prop explicitly.
+    private const val DEFAULT_BLUR_ROUNDS = 5
     // Capture/blur bitmap is scaled down by this factor before the root is
     // drawn into it. A higher factor shrinks the raster area quadratically,
     // reducing both the software capture cost and the blur cost.
@@ -232,7 +234,7 @@ class ReactNativeBlurView : BlurViewGroup {
 
   fun setBlurAmount(amount: Float) {
     currentBlurRadius = mapBlurAmountToRadius(amount)
-    logDebug("setBlurAmount: $amount -> $currentBlurRadius (mapped from 0-100 to 0-25 range)")
+    logDebug("setBlurAmount: $amount -> $currentBlurRadius")
 
     try {
       super.setBlurRadius(currentBlurRadius)

--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeProgressiveBlurView.kt
@@ -51,9 +51,10 @@ class ReactNativeProgressiveBlurView : FrameLayout {
     private const val TAG = "ReactNativeProgressiveBlur"
     private const val MAX_BLUR_RADIUS = 100f
     private const val DEFAULT_BLUR_RADIUS = 10f
-    // See ReactNativeBlurView for the rationale behind these two values: fewer
-    // blur passes and a smaller capture bitmap both reduce per-frame CPU cost.
-    private const val DEFAULT_BLUR_ROUNDS = 3
+    // Kept at 5 to match the JS wrapper and codegen default (one source of
+    // truth); the wrapper always sends blurRounds so a lower internal default
+    // was never reachable. See ReactNativeBlurView for the downsample rationale.
+    private const val DEFAULT_BLUR_ROUNDS = 5
     private const val DEFAULT_DOWNSAMPLE_FACTOR = 8.0f
     private const val DEBUG = false
 
@@ -76,7 +77,8 @@ class ReactNativeProgressiveBlurView : FrameLayout {
     }
 
     /**
-     * Maps blur amount (0-100) to Android blur radius (0-25).
+     * Maps blur amount (0-100) 1:1 to the QmBlurView blur radius, matching
+     * ReactNativeBlurView.
      */
     private fun mapBlurAmountToRadius(amount: Float): Float {
       if (amount.isNaN() || amount.isInfinite()) {
@@ -84,7 +86,7 @@ class ReactNativeProgressiveBlurView : FrameLayout {
         return DEFAULT_BLUR_RADIUS
       }
       val clampedAmount = amount.coerceIn(MIN_BLUR_AMOUNT, MAX_BLUR_AMOUNT)
-      return (clampedAmount / MAX_BLUR_RADIUS) * MAX_BLUR_RADIUS
+      return (clampedAmount / MAX_BLUR_AMOUNT) * MAX_BLUR_RADIUS
     }
   }
 

--- a/ios/ReactNativeProgressiveBlurView.mm
+++ b/ios/ReactNativeProgressiveBlurView.mm
@@ -150,7 +150,10 @@ using namespace facebook::react;
     // Set initial properties from default props
     [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withBlurAmount:pbvProps.blurAmount];
 
-    if (pbvProps.blurType != facebook::react::ReactNativeProgressiveBlurViewBlurType::Xlight) {
+    // This component's default blurType is Regular (not Xlight); compare
+    // against the correct default so the initial apply is skipped only when the
+    // value actually is the default.
+    if (pbvProps.blurType != facebook::react::ReactNativeProgressiveBlurViewBlurType::Regular) {
       NSString *blurTypeString = [[NSString alloc] initWithUTF8String:toString(pbvProps.blurType).c_str()];
       [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withBlurType:blurTypeString];
     }

--- a/src/BlurView.tsx
+++ b/src/BlurView.tsx
@@ -54,7 +54,7 @@ export interface BlurViewProps {
   style?: StyleProp<ViewStyle>;
 
   /**
-   * @description style object for the blur view
+   * @description Whether the blur view should ignore safe area insets
    *
    * @default true
    */

--- a/src/LiquidGlassContainer.tsx
+++ b/src/LiquidGlassContainer.tsx
@@ -54,3 +54,5 @@ export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
     </ReactNativeLiquidGlassContainer>
   );
 };
+
+export default LiquidGlassContainer;

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -57,7 +57,7 @@ export interface LiquidGlassViewProps {
   /**
    * @description Whether the glass view should ignore safe area insets
    *
-   * @default false
+   * @default true
    *
    * @platform iOS
    */

--- a/src/ReactNativeLiquidGlassContainerNativeComponent.ts
+++ b/src/ReactNativeLiquidGlassContainerNativeComponent.ts
@@ -1,9 +1,12 @@
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps } from 'react-native';
-import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
+import type {
+  Double,
+  WithDefault,
+} from 'react-native/Libraries/Types/CodegenTypes';
 
 interface NativeProps extends ViewProps {
-  spacing?: Double;
+  spacing?: WithDefault<Double, 0>;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/VibrancyView.tsx
+++ b/src/VibrancyView.tsx
@@ -78,3 +78,5 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
 });
+
+export default VibrancyView;


### PR DESCRIPTION
Part 4 of 6 in the July 2026 audit remediation. **Stacked on `fix/ios-pr3-lifecycle`.**

Codegen contract alignment across native and JS.

- **AND-03** BlurSwitchManager adopts the generated codegen delegate (props flow through codegen like the other two managers).
- **AND-04** unify the `blurAmount`→radius mapping. Per maintainer decision the two blur views keep their current 1:1 strength and **BlurSwitch is brought up to match** (no rendering change for the blur views); misleading "0-25" comments removed.
- **AND-05** native `blurRounds` default set to 5 (single source of truth).
- **TS-03** `ignoreSafeArea` JSDoc/default fixes; **TS-07** `spacing` WithDefault + missing default exports; **IOS-NEW-4** progressive init compares the correct default.

Deferred by decision: TS-NEW-1 (ColorValue-typed colour props).

Verified: Android + iOS build; tsc clean; the switch renders + toggles through the new delegate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased maximum blur intensity for Android blur switches.
  - Added default imports for `LiquidGlassContainer` and `VibrancyView`.
  - Added a default spacing value of `0` for liquid glass containers.

- **Bug Fixes**
  - Improved blur behavior and default blur-round consistency across platforms.
  - Corrected iOS initial blur-type handling.
  - Updated inaccurate safe-area documentation and prop defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->