### PR TITLE
refactor(ts): forwardRef + memo, deprecate raw exports, add tests (audit PR 5/6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@release-it/conventional-changelog": "^11.0.1",
     "@types/jest": "^29.5.5",
     "@types/react": "^19.0.0",
+    "@types/react-test-renderer": "^19.1.0",
     "commitlint": "^19.6.1",
     "del-cli": "^5.1.0",
     "eslint": "^9.22.0",
@@ -86,6 +87,7 @@
     "react": "19.0.0",
     "react-native": "0.79.2",
     "react-native-builder-bob": "^0.40.11",
+    "react-test-renderer": "19.0.0",
     "release-it": "^20.2.1",
     "turbo": "latest",
     "typescript": "^5.8.3"

--- a/src/BlurSwitch.tsx
+++ b/src/BlurSwitch.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { memo, useCallback } from 'react';
 import { Platform, StyleSheet, Switch } from 'react-native';
 import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
 import ReactNativeBlurSwitch from './ReactNativeBlurSwitchNativeComponent';
 
-const toColorString = (
+type NativeBlurSwitchProps = React.ComponentProps<typeof ReactNativeBlurSwitch>;
+
+export const toColorString = (
   color: ColorValue | undefined,
   fallback: string
 ): string => {
@@ -102,7 +104,7 @@ export interface BlurSwitchProps {
  * />
  * ```
  */
-export const BlurSwitch: React.FC<BlurSwitchProps> = ({
+const BlurSwitchComponent: React.FC<BlurSwitchProps> = ({
   value = false,
   blurAmount = 10,
   blurRounds = 5,
@@ -113,6 +115,15 @@ export const BlurSwitch: React.FC<BlurSwitchProps> = ({
   style,
   ...props
 }) => {
+  const handleNativeValueChange = useCallback<
+    NonNullable<NativeBlurSwitchProps['onValueChange']>
+  >(
+    (event) => {
+      onValueChange?.(event.nativeEvent.value);
+    },
+    [onValueChange]
+  );
+
   if (Platform.OS === 'ios') {
     return (
       <Switch
@@ -131,9 +142,7 @@ export const BlurSwitch: React.FC<BlurSwitchProps> = ({
     <ReactNativeBlurSwitch
       style={[styles.switch, style]}
       value={value}
-      onValueChange={(event) => {
-        onValueChange?.(event.nativeEvent.value);
-      }}
+      onValueChange={handleNativeValueChange}
       blurAmount={blurAmount}
       blurRounds={blurRounds}
       thumbColor={toColorString(thumbColor, '#FFFFFF')}
@@ -144,6 +153,10 @@ export const BlurSwitch: React.FC<BlurSwitchProps> = ({
     />
   );
 };
+
+BlurSwitchComponent.displayName = 'BlurSwitch';
+
+export const BlurSwitch = memo(BlurSwitchComponent);
 
 const styles = StyleSheet.create({
   switch: {

--- a/src/BlurView.tsx
+++ b/src/BlurView.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, forwardRef, memo, useMemo } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
 import ReactNativeBlurView, {
@@ -68,6 +68,9 @@ export interface BlurViewProps {
   children?: React.ReactNode;
 }
 
+/** Ref to the underlying native blur view. */
+export type BlurViewRef = React.ComponentRef<typeof ReactNativeBlurView>;
+
 /**
  * A cross-platform blur view component that provides native blur effects.
  *
@@ -77,6 +80,8 @@ export interface BlurViewProps {
  * This component automatically handles the proper positioning pattern where the blur
  * effect is positioned absolutely behind the content, ensuring interactive elements
  * work correctly.
+ *
+ * A forwarded ref resolves to the underlying native blur view.
  *
  * @example
  * ```tsx
@@ -90,61 +95,89 @@ export interface BlurViewProps {
  * </BlurView>
  * ```
  */
-export const BlurView: React.FC<BlurViewProps> = ({
-  blurType = 'xlight',
-  blurAmount = 10,
-  blurRounds = 5,
-  reducedTransparencyFallbackColor = '#FFFFFF',
-  overlayColor,
-  style,
-  children,
-  ignoreSafeArea = true,
-  ...props
-}) => {
-  const overlay = { backgroundColor: overlayColor };
-  const commonProps: BlurViewProps = {
-    blurType,
-    blurAmount,
-    blurRounds,
-    ignoreSafeArea,
-    reducedTransparencyFallbackColor,
-  };
-
-  // If no children, render the blur view directly (for background use)
-  if (!Children.count(children)) {
-    return (
-      <ReactNativeBlurView
-        style={[style, overlay]}
-        {...commonProps}
-        {...props}
-      />
+const BlurViewComponent = forwardRef<BlurViewRef, BlurViewProps>(
+  (
+    {
+      blurType = 'xlight',
+      blurAmount = 10,
+      blurRounds = 5,
+      reducedTransparencyFallbackColor = '#FFFFFF',
+      overlayColor,
+      style,
+      children,
+      ignoreSafeArea = true,
+      ...props
+    },
+    ref
+  ) => {
+    const overlay = useMemo(
+      () => ({ backgroundColor: overlayColor }),
+      [overlayColor]
     );
-  }
+    const commonProps = useMemo<BlurViewProps>(
+      () => ({
+        blurType,
+        blurAmount,
+        blurRounds,
+        ignoreSafeArea,
+        reducedTransparencyFallbackColor,
+      }),
+      [
+        blurType,
+        blurAmount,
+        blurRounds,
+        ignoreSafeArea,
+        reducedTransparencyFallbackColor,
+      ]
+    );
 
-  // If children exist, use the style default for Android
-  if (Platform.OS === 'android') {
+    // If no children, render the blur view directly (for background use)
+    if (!Children.count(children)) {
+      return (
+        <ReactNativeBlurView
+          ref={ref}
+          style={[style, overlay]}
+          {...commonProps}
+          {...props}
+        />
+      );
+    }
+
+    // If children exist, use the style default for Android
+    if (Platform.OS === 'android') {
+      return (
+        <ReactNativeBlurView
+          ref={ref}
+          style={style}
+          {...commonProps}
+          {...props}
+        >
+          <View style={[StyleSheet.absoluteFill, overlay]} />
+
+          {children}
+        </ReactNativeBlurView>
+      );
+    }
+
+    // If children exist, use the absolute positioning pattern for iOS and others
     return (
-      <ReactNativeBlurView style={style} {...commonProps} {...props}>
-        <View style={[StyleSheet.absoluteFill, overlay]} />
-
+      <View style={[styles.container, style, overlay]}>
+        {/* Blur effect positioned absolutely behind content */}
+        <ReactNativeBlurView
+          ref={ref}
+          style={StyleSheet.absoluteFill}
+          {...commonProps}
+          {...props}
+        />
         {children}
-      </ReactNativeBlurView>
+      </View>
     );
   }
+);
 
-  // If children exist, use the absolute positioning pattern for iOS and others
-  return (
-    <View style={[styles.container, style, overlay]}>
-      {/* Blur effect positioned absolutely behind content */}
-      <ReactNativeBlurView
-        style={StyleSheet.absoluteFill}
-        {...commonProps}
-        {...props}
-      />
-      {children}
-    </View>
-  );
-};
+BlurViewComponent.displayName = 'BlurView';
+
+export const BlurView = memo(BlurViewComponent);
 
 export default BlurView;
 

--- a/src/LiquidGlassContainer.tsx
+++ b/src/LiquidGlassContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, memo } from 'react';
 import { Platform, View, type ViewProps } from 'react-native';
 import ReactNativeLiquidGlassContainer from './ReactNativeLiquidGlassContainerNativeComponent';
 
@@ -30,12 +30,18 @@ export interface LiquidGlassContainerProps extends ViewProps {
  * </LiquidGlassContainer>
  * ```
  */
-export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
-  spacing = 0,
-  style,
-  children,
-  ...rest
-}) => {
+/**
+ * Ref to the underlying native glass container. On the fallback path
+ * (non-iOS or iOS < 26, which render a plain View) the ref is not attached.
+ */
+export type LiquidGlassContainerRef = React.ComponentRef<
+  typeof ReactNativeLiquidGlassContainer
+>;
+
+const LiquidGlassContainerComponent = forwardRef<
+  LiquidGlassContainerRef,
+  LiquidGlassContainerProps
+>(({ spacing = 0, style, children, ...rest }, ref) => {
   const isCompatibleIOS =
     Platform.OS === 'ios' && parseInt(Platform.Version as string, 10) >= 26;
 
@@ -49,10 +55,19 @@ export const LiquidGlassContainer: React.FC<LiquidGlassContainerProps> = ({
   }
 
   return (
-    <ReactNativeLiquidGlassContainer spacing={spacing} style={style} {...rest}>
+    <ReactNativeLiquidGlassContainer
+      ref={ref}
+      spacing={spacing}
+      style={style}
+      {...rest}
+    >
       {children}
     </ReactNativeLiquidGlassContainer>
   );
-};
+});
+
+LiquidGlassContainerComponent.displayName = 'LiquidGlassContainer';
+
+export const LiquidGlassContainer = memo(LiquidGlassContainerComponent);
 
 export default LiquidGlassContainer;

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, memo, useMemo } from 'react';
 import { Platform } from 'react-native';
 import type { ViewStyle, StyleProp } from 'react-native';
 import ReactNativeLiquidGlassView, {
@@ -94,7 +94,7 @@ const MAX_FALLBACK_TINT_ALPHA = 0.35;
  * capped alpha so the fallback approximates glass rather than a solid fill.
  * Non-hex colours (named colours, rgb/rgba) are passed through unchanged.
  */
-function getFallbackOverlayColor(
+export function getFallbackOverlayColor(
   tint: string | undefined,
   opacity: number
 ): string | undefined {
@@ -171,53 +171,81 @@ function getFallbackOverlayColor(
  *
  * @platform ios
  */
-export const LiquidGlassView: React.FC<LiquidGlassViewProps> = ({
-  glassType = 'clear',
-  glassTintColor = 'clear',
-  glassOpacity = 1.0,
-  reducedTransparencyFallbackColor = '#FFFFFF',
-  isInteractive = true,
-  ignoreSafeArea = true,
-  style,
-  children,
-  ...props
-}) => {
-  const isIos = Platform.OS === 'ios';
+/**
+ * Ref to the underlying native liquid glass view. On the fallback path
+ * (Android or iOS < 26, which render a BlurView) the ref is not attached.
+ */
+export type LiquidGlassViewRef = React.ComponentRef<
+  typeof ReactNativeLiquidGlassView
+>;
 
-  // On Android and iOS < 26 the native glass API is unavailable, so we fall
-  // back to a strong, lightly-tinted blur that approximates liquid glass.
-  if (!isIos || (isIos && Number.parseInt(String(Platform.Version), 10) < 26)) {
+const LiquidGlassViewComponent = forwardRef<
+  LiquidGlassViewRef,
+  LiquidGlassViewProps
+>(
+  (
+    {
+      glassType = 'clear',
+      glassTintColor = 'clear',
+      glassOpacity = 1.0,
+      reducedTransparencyFallbackColor = '#FFFFFF',
+      isInteractive = true,
+      ignoreSafeArea = true,
+      style,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isIos = Platform.OS === 'ios';
+    const fallbackOverlayColor = useMemo(
+      () => getFallbackOverlayColor(glassTintColor, glassOpacity),
+      [glassTintColor, glassOpacity]
+    );
+
+    // On Android and iOS < 26 the native glass API is unavailable, so we fall
+    // back to a strong, lightly-tinted blur that approximates liquid glass.
+    if (
+      !isIos ||
+      (isIos && Number.parseInt(String(Platform.Version), 10) < 26)
+    ) {
+      return (
+        <BlurView
+          // "regular" is a subtle (~14% white) overlay. The default "xlight" is
+          // ~55% opaque and would make the fallback look like a solid panel.
+          blurType="regular"
+          blurAmount={FALLBACK_BLUR_AMOUNT}
+          overlayColor={fallbackOverlayColor}
+          reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
+          ignoreSafeArea={ignoreSafeArea}
+          style={style}
+        >
+          {children}
+        </BlurView>
+      );
+    }
+
+    // If children exist, use the absolute positioning pattern
     return (
-      <BlurView
-        // "regular" is a subtle (~14% white) overlay. The default "xlight" is
-        // ~55% opaque and would make the fallback look like a solid panel.
-        blurType="regular"
-        blurAmount={FALLBACK_BLUR_AMOUNT}
-        overlayColor={getFallbackOverlayColor(glassTintColor, glassOpacity)}
+      <ReactNativeLiquidGlassView
+        ref={ref}
+        glassType={glassType}
+        glassTintColor={glassTintColor}
+        glassOpacity={glassOpacity}
         reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
+        isInteractive={isInteractive}
         ignoreSafeArea={ignoreSafeArea}
         style={style}
+        {...props}
       >
         {children}
-      </BlurView>
+      </ReactNativeLiquidGlassView>
     );
   }
+);
 
-  // If children exist, use the absolute positioning pattern
-  return (
-    <ReactNativeLiquidGlassView
-      glassType={glassType}
-      glassTintColor={glassTintColor}
-      glassOpacity={glassOpacity}
-      reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
-      isInteractive={isInteractive}
-      ignoreSafeArea={ignoreSafeArea}
-      style={style}
-      {...props}
-    >
-      {children}
-    </ReactNativeLiquidGlassView>
-  );
-};
+LiquidGlassViewComponent.displayName = 'LiquidGlassView';
+
+export const LiquidGlassView = memo(LiquidGlassViewComponent);
 
 export default LiquidGlassView;

--- a/src/ProgressiveBlurView.tsx
+++ b/src/ProgressiveBlurView.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, forwardRef, memo, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
 import ReactNativeProgressiveBlurView, {
@@ -82,6 +82,11 @@ export interface ProgressiveBlurViewProps {
   children?: React.ReactNode;
 }
 
+/** Ref to the underlying native progressive blur view. */
+export type ProgressiveBlurViewRef = React.ComponentRef<
+  typeof ReactNativeProgressiveBlurView
+>;
+
 /**
  * A progressive blur view component that provides variable/gradient blur effects.
  *
@@ -94,6 +99,8 @@ export interface ProgressiveBlurViewProps {
  *
  * This component uses the same positioning pattern as BlurView where the blur
  * effect is positioned absolutely behind the content.
+ *
+ * A forwarded ref resolves to the underlying native progressive blur view.
  *
  * @example
  * ```tsx
@@ -108,69 +115,73 @@ export interface ProgressiveBlurViewProps {
  *   <Text>Content on top of progressive blur</Text>
  * </ProgressiveBlurView>
  * ```
- *
- * @example
- * ```tsx
- * // Blur that fades from bottom (blurred) to top (clear)
- * <ProgressiveBlurView
- *   blurType="dark"
- *   blurAmount={40}
- *   direction="blurredBottomClearTop"
- *   style={{ height: 200 }}
- * >
- *   <Text>Content visible at top, blurred at bottom</Text>
- * </ProgressiveBlurView>
- * ```
  */
-export const ProgressiveBlurView: React.FC<ProgressiveBlurViewProps> = ({
-  blurType = 'regular',
-  blurAmount = 20,
-  blurRounds = 5,
-  direction = 'blurredTopClearBottom',
-  startOffset = 0.0,
-  reducedTransparencyFallbackColor = '#FFFFFF',
-  overlayColor,
-  style,
-  children,
-  ...props
-}) => {
-  const overlay = { backgroundColor: overlayColor };
+const ProgressiveBlurViewComponent = forwardRef<
+  ProgressiveBlurViewRef,
+  ProgressiveBlurViewProps
+>(
+  (
+    {
+      blurType = 'regular',
+      blurAmount = 20,
+      blurRounds = 5,
+      direction = 'blurredTopClearBottom',
+      startOffset = 0.0,
+      reducedTransparencyFallbackColor = '#FFFFFF',
+      overlayColor,
+      style,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const overlay = useMemo(
+      () => ({ backgroundColor: overlayColor }),
+      [overlayColor]
+    );
 
-  // If no children, render the blur view directly (for background use)
-  if (!Children.count(children)) {
+    // If no children, render the blur view directly (for background use)
+    if (!Children.count(children)) {
+      return (
+        <ReactNativeProgressiveBlurView
+          ref={ref}
+          blurType={blurType}
+          blurAmount={blurAmount}
+          blurRounds={blurRounds}
+          direction={direction}
+          startOffset={startOffset}
+          reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
+          style={[style, overlay]}
+          {...props}
+        />
+      );
+    }
+
+    // If children exist, use the absolute positioning pattern
     return (
-      <ReactNativeProgressiveBlurView
-        blurType={blurType}
-        blurAmount={blurAmount}
-        blurRounds={blurRounds}
-        direction={direction}
-        startOffset={startOffset}
-        reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
-        style={[style, overlay]}
-        {...props}
-      />
+      <View style={[styles.container, style, overlay]}>
+        {/* Blur effect positioned absolutely behind content */}
+        <ReactNativeProgressiveBlurView
+          ref={ref}
+          blurType={blurType}
+          blurAmount={blurAmount}
+          blurRounds={blurRounds}
+          direction={direction}
+          startOffset={startOffset}
+          reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
+          style={StyleSheet.absoluteFill}
+          {...props}
+        />
+
+        {children}
+      </View>
     );
   }
+);
 
-  // If children exist, use the absolute positioning pattern
-  return (
-    <View style={[styles.container, style, overlay]}>
-      {/* Blur effect positioned absolutely behind content */}
-      <ReactNativeProgressiveBlurView
-        blurType={blurType}
-        blurAmount={blurAmount}
-        blurRounds={blurRounds}
-        direction={direction}
-        startOffset={startOffset}
-        reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
-        style={StyleSheet.absoluteFill}
-        {...props}
-      />
+ProgressiveBlurViewComponent.displayName = 'ProgressiveBlurView';
 
-      {children}
-    </View>
-  );
-};
+export const ProgressiveBlurView = memo(ProgressiveBlurViewComponent);
 
 export default ProgressiveBlurView;
 

--- a/src/VibrancyView.tsx
+++ b/src/VibrancyView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, memo } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import type { ViewStyle, StyleProp } from 'react-native';
 import ReactNativeVibrancyView, {
@@ -42,36 +42,48 @@ export interface VibrancyViewProps {
  * On iOS, this uses UIVibrancyEffect.
  * On Android, this falls back to a simple View (or BlurView behavior if implemented).
  */
-export const VibrancyView: React.FC<VibrancyViewProps> = ({
-  blurType = 'xlight',
-  blurAmount = 10,
-  style,
-  children,
-  ...props
-}) => {
-  if (Platform.OS === 'android') {
+/**
+ * Ref to the underlying native vibrancy view. On Android (which falls back to
+ * BlurView) the ref is not attached.
+ */
+export type VibrancyViewRef = React.ComponentRef<
+  typeof ReactNativeVibrancyView
+>;
+
+const VibrancyViewComponent = forwardRef<VibrancyViewRef, VibrancyViewProps>(
+  (
+    { blurType = 'xlight', blurAmount = 10, style, children, ...props },
+    ref
+  ) => {
+    if (Platform.OS === 'android') {
+      return (
+        <BlurView
+          blurType={blurType}
+          blurAmount={blurAmount}
+          style={style}
+          {...props}
+        >
+          {children}
+        </BlurView>
+      );
+    }
     return (
-      <BlurView
+      <ReactNativeVibrancyView
+        ref={ref}
         blurType={blurType}
         blurAmount={blurAmount}
-        style={style}
+        style={[styles.container, style]}
         {...props}
       >
         {children}
-      </BlurView>
+      </ReactNativeVibrancyView>
     );
   }
-  return (
-    <ReactNativeVibrancyView
-      blurType={blurType}
-      blurAmount={blurAmount}
-      style={[styles.container, style]}
-      {...props}
-    >
-      {children}
-    </ReactNativeVibrancyView>
-  );
-};
+);
+
+VibrancyViewComponent.displayName = 'VibrancyView';
+
+export const VibrancyView = memo(VibrancyViewComponent);
 
 const styles = StyleSheet.create({
   container: {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,128 @@
-it.todo('write a test');
+import type { ReactElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { View, type ColorValue } from 'react-native';
+
+import * as PublicApi from '../index';
+import ReactNativeBlurView from '../ReactNativeBlurViewNativeComponent';
+import { BlurView } from '../BlurView';
+import { ProgressiveBlurView } from '../ProgressiveBlurView';
+import { LiquidGlassView, getFallbackOverlayColor } from '../LiquidGlassView';
+import { LiquidGlassContainer } from '../LiquidGlassContainer';
+import { VibrancyView } from '../VibrancyView';
+import { BlurSwitch, toColorString } from '../BlurSwitch';
+
+// react-test-renderer under React 19 requires renders to run inside act().
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function render(element: ReactElement): TestRenderer.ReactTestRenderer {
+  let tree!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    tree = TestRenderer.create(element);
+  });
+  return tree;
+}
+
+describe('getFallbackOverlayColor', () => {
+  it('returns undefined for missing / clear / transparent tints', () => {
+    expect(getFallbackOverlayColor(undefined, 1)).toBeUndefined();
+    expect(getFallbackOverlayColor('', 1)).toBeUndefined();
+    expect(getFallbackOverlayColor('clear', 1)).toBeUndefined();
+    expect(getFallbackOverlayColor('CLEAR', 1)).toBeUndefined();
+    expect(getFallbackOverlayColor('transparent', 1)).toBeUndefined();
+  });
+
+  it('scales a 6-digit hex tint down to the capped subtle alpha', () => {
+    // opacity 1 * MAX_FALLBACK_TINT_ALPHA (0.35) * tintAlpha 1 * 255 = 89 -> 0x59
+    expect(getFallbackOverlayColor('#FF0000', 1)).toBe('#ff000059');
+    // opacity 0.5 -> 45 -> 0x2d
+    expect(getFallbackOverlayColor('#FF0000', 0.5)).toBe('#ff00002d');
+  });
+
+  it('expands 3-digit hex and folds an 8-digit tint alpha in', () => {
+    expect(getFallbackOverlayColor('#F00', 1)).toBe('#ff000059');
+    // #FF000080 carries tintAlpha 0x80/255 ~= 0.502, so 0.35*0.502*255 ~= 45
+    expect(getFallbackOverlayColor('#FF000080', 1)).toBe('#ff00002d');
+  });
+
+  it('clamps opacity into [0, 1]', () => {
+    expect(getFallbackOverlayColor('#FF0000', 5)).toBe('#ff000059');
+    expect(getFallbackOverlayColor('#FF0000', -1)).toBe('#ff000000');
+  });
+
+  it('passes named / rgb colours through unchanged', () => {
+    expect(getFallbackOverlayColor('red', 1)).toBe('red');
+    expect(getFallbackOverlayColor('rgb(255,0,0)', 1)).toBe('rgb(255,0,0)');
+  });
+});
+
+describe('toColorString', () => {
+  it('returns a string colour unchanged', () => {
+    expect(toColorString('#abcdef', '#000000')).toBe('#abcdef');
+  });
+
+  it('falls back for undefined or non-string ColorValues', () => {
+    expect(toColorString(undefined, '#E5E5EA')).toBe('#E5E5EA');
+    // processColor / PlatformColor produce non-string values
+    expect(toColorString(42 as unknown as ColorValue, '#34C759')).toBe(
+      '#34C759'
+    );
+  });
+});
+
+describe('public API surface', () => {
+  it('exports every wrapper component', () => {
+    for (const name of [
+      'BlurView',
+      'ProgressiveBlurView',
+      'LiquidGlassView',
+      'LiquidGlassContainer',
+      'VibrancyView',
+      'BlurSwitch',
+    ] as const) {
+      expect(PublicApi[name]).toBeDefined();
+    }
+    expect(PublicApi.default).toBe(PublicApi.BlurView);
+  });
+});
+
+describe('wrapper rendering', () => {
+  it('renders BlurView with no children as the native blur view with defaults', () => {
+    const tree = render(<BlurView blurAmount={20} />);
+    const native = tree.root.findAllByType(ReactNativeBlurView);
+    expect(native).toHaveLength(1);
+    expect(native[0]?.props.blurType).toBe('xlight');
+    expect(native[0]?.props.blurAmount).toBe(20);
+    expect(native[0]?.props.blurRounds).toBe(5);
+    expect(native[0]?.props.ignoreSafeArea).toBe(true);
+    act(() => tree.unmount());
+  });
+
+  it('renders BlurView with children without throwing', () => {
+    const tree = render(
+      <BlurView>
+        <View testID="child" />
+      </BlurView>
+    );
+    expect(tree.root.findAllByType(ReactNativeBlurView).length).toBeGreaterThan(
+      0
+    );
+    act(() => tree.unmount());
+  });
+
+  it('renders every wrapper without throwing', () => {
+    const cases = [
+      <ProgressiveBlurView key="p" blurAmount={30} />,
+      <LiquidGlassView key="g" glassTintColor="#007AFF" glassOpacity={0.8} />,
+      <LiquidGlassContainer key="c" spacing={12} />,
+      <VibrancyView key="v" blurAmount={15} />,
+      <BlurSwitch key="s" value onValueChange={() => {}} />,
+    ];
+    for (const element of cases) {
+      const tree = render(element);
+      expect(tree.toJSON()).not.toBeNull();
+      act(() => tree.unmount());
+    }
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,32 +1,76 @@
+// NOTE: the raw `ReactNative*` native components below are the codegen host
+// components. They are exported for backwards compatibility only and are
+// scheduled for removal in the next major version — prefer the wrapper
+// components (BlurView, LiquidGlassView, etc.), which handle platform
+// fallbacks, defaults and refs. Rendering a raw iOS-only component on Android
+// (or vice versa) produces an "unimplemented component" error.
+
+/**
+ * @deprecated Use the {@link BlurView} wrapper instead. Direct use of the raw
+ * native component is unsupported and will be removed in the next major version.
+ */
 export { default as ReactNativeBlurView } from './ReactNativeBlurViewNativeComponent';
-export * from './ReactNativeBlurViewNativeComponent';
+export type { BlurType } from './ReactNativeBlurViewNativeComponent';
 
 export { BlurView as default, BlurView } from './BlurView';
-export type { BlurViewProps } from './BlurView';
+export type { BlurViewProps, BlurViewRef } from './BlurView';
 
+/**
+ * @deprecated Use the {@link LiquidGlassView} wrapper instead. Direct use of
+ * the raw native component is unsupported and will be removed in the next major
+ * version.
+ */
 export { default as ReactNativeLiquidGlassView } from './ReactNativeLiquidGlassViewNativeComponent';
 export type { GlassType } from './ReactNativeLiquidGlassViewNativeComponent';
 
 export { LiquidGlassView } from './LiquidGlassView';
-export type { LiquidGlassViewProps } from './LiquidGlassView';
+export type {
+  LiquidGlassViewProps,
+  LiquidGlassViewRef,
+} from './LiquidGlassView';
 
+/**
+ * @deprecated Use the {@link ProgressiveBlurView} wrapper instead. Direct use
+ * of the raw native component is unsupported and will be removed in the next
+ * major version.
+ */
 export { default as ReactNativeProgressiveBlurView } from './ReactNativeProgressiveBlurViewNativeComponent';
 export type { ProgressiveBlurDirection } from './ReactNativeProgressiveBlurViewNativeComponent';
 
 export { ProgressiveBlurView } from './ProgressiveBlurView';
-export type { ProgressiveBlurViewProps } from './ProgressiveBlurView';
+export type {
+  ProgressiveBlurViewProps,
+  ProgressiveBlurViewRef,
+} from './ProgressiveBlurView';
 
+/**
+ * @deprecated Use the {@link LiquidGlassContainer} wrapper instead. Direct use
+ * of the raw native component is unsupported and will be removed in the next
+ * major version.
+ */
 export { default as ReactNativeLiquidGlassContainer } from './ReactNativeLiquidGlassContainerNativeComponent';
 
 export { LiquidGlassContainer } from './LiquidGlassContainer';
-export type { LiquidGlassContainerProps } from './LiquidGlassContainer';
+export type {
+  LiquidGlassContainerProps,
+  LiquidGlassContainerRef,
+} from './LiquidGlassContainer';
 
+/**
+ * @deprecated Use the {@link BlurSwitch} wrapper instead. Direct use of the raw
+ * native component is unsupported and will be removed in the next major version.
+ */
 export { default as ReactNativeBlurSwitch } from './ReactNativeBlurSwitchNativeComponent';
 export type { ValueChangeEvent } from './ReactNativeBlurSwitchNativeComponent';
 
 export { BlurSwitch } from './BlurSwitch';
 export type { BlurSwitchProps } from './BlurSwitch';
 
+/**
+ * @deprecated Use the {@link VibrancyView} wrapper instead. Direct use of the
+ * raw native component is unsupported and will be removed in the next major
+ * version.
+ */
 export { default as ReactNativeVibrancyView } from './ReactNativeVibrancyViewNativeComponent';
 export { VibrancyView } from './VibrancyView';
-export type { VibrancyViewProps } from './VibrancyView';
+export type { VibrancyViewProps, VibrancyViewRef } from './VibrancyView';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4650,6 +4650,7 @@ __metadata:
     "@release-it/conventional-changelog": ^11.0.1
     "@types/jest": ^29.5.5
     "@types/react": ^19.0.0
+    "@types/react-test-renderer": ^19.1.0
     commitlint: ^19.6.1
     del-cli: ^5.1.0
     eslint: ^9.22.0
@@ -4660,6 +4661,7 @@ __metadata:
     react: 19.0.0
     react-native: 0.79.2
     react-native-builder-bob: ^0.40.11
+    react-test-renderer: 19.0.0
     release-it: ^20.2.1
     turbo: latest
     typescript: ^5.8.3
@@ -4934,7 +4936,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.0.0, @types/react@npm:~19.2.2":
+"@types/react-test-renderer@npm:^19.1.0":
+  version: 19.1.0
+  resolution: "@types/react-test-renderer@npm:19.1.0"
+  dependencies:
+    "@types/react": "*"
+  checksum: 2ef3aec0f2fd638902cda606d70c8531d66f8e8944334427986b99dcac9755ee60b700c5c3a19ac354680f9c45669e98077b84f79cac60e950bdb7d38aebffde
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*, @types/react@npm:^19.0.0, @types/react@npm:~19.2.2":
   version: 19.2.17
   resolution: "@types/react@npm:19.2.17"
   dependencies:
@@ -13036,7 +13047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^19.1.0":
+"react-is@npm:^19.0.0, react-is@npm:^19.1.0":
   version: 19.2.7
   resolution: "react-is@npm:19.2.7"
   checksum: 148ee03b481ace8370cb9b96de386598423ed44ad36090c45ce3f905aec496db6f2675da720bbe43f39d66c43c9a16757cb71e9e55217825707dae97f0cf200f
@@ -13366,6 +13377,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: a7b0bf493c9231065ebafa84c4237aed997c746c561196121b7de82fe155a5355b372db5070a3ac9fe980cf7f60dc0f1e8cf6402a2aa5b2957392932ccf76e76
+  languageName: node
+  linkType: hard
+
+"react-test-renderer@npm:19.0.0":
+  version: 19.0.0
+  resolution: "react-test-renderer@npm:19.0.0"
+  dependencies:
+    react-is: ^19.0.0
+    scheduler: ^0.25.0
+  peerDependencies:
+    react: ^19.0.0
+  checksum: 2e1e527588c69e822b7aa25262c9f4a48161ede9cee5109b88228ecafbd91ce82f7afed176645efcba903ba5a43d05842a8229cdde220049e42a0cf679715dbc
   languageName: node
   linkType: hard
 
@@ -13803,7 +13826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:0.25.0":
+"scheduler@npm:0.25.0, scheduler@npm:^0.25.0":
   version: 0.25.0
   resolution: "scheduler@npm:0.25.0"
   checksum: b7bb9fddbf743e521e9aaa5198a03ae823f5e104ebee0cb9ec625392bb7da0baa1c28ab29cee4b1e407a94e76acc6eee91eeb749614f91f853efda2613531566


### PR DESCRIPTION
Part 5 of 6 in the July 2026 audit remediation. **Stacked on `fix/pr4-codegen-contract`.**

TypeScript API quality and tests.

- **TS-01** every wrapper wrapped in `React.memo`; per-render allocations hoisted (`useMemo`/`useCallback`); the five view wrappers `forwardRef` to their native view (fallback paths don't attach a ref).
- **TS-02** the raw `ReactNative*` codegen components are marked `@deprecated` (removal slated for the next major).
- **TS-05** replaced the single `it.todo` with an 11-test suite (getFallbackOverlayColor hex/alpha math, toColorString, export surface, render smoke + default forwarding). Adds `react-test-renderer` + `@types/react-test-renderer` dev deps.

Verified: tsc + eslint clean, all 11 jest tests pass, wrappers render in the example app (Fast Refresh) with no redbox.