### PR TITLE
fix(ios): remove shadowed `_props` ivars (crash on react-native 0.87)

### DIFF
--- a/ios/ReactNativeBlurView.mm
+++ b/ios/ReactNativeBlurView.mm
@@ -20,7 +20,6 @@ using namespace facebook::react;
 
 @implementation ReactNativeBlurView {
   AdvancedBlurView *_advancedBlurView;
-  Props::Shared _props;
 }
 
 + (UIColor *)colorFromString:(NSString *)colorString {
@@ -207,9 +206,6 @@ using namespace facebook::react;
   if (oldViewProps.ignoreSafeArea != newViewProps.ignoreSafeArea) {
     [ReactNativeBlurViewHelper updateBlurView:_advancedBlurView withIgnoringSafeArea:newViewProps.ignoreSafeArea];
   }
-
-  // Store the new props
-  _props = props;
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/ios/ReactNativeLiquidGlassContainer.mm
+++ b/ios/ReactNativeLiquidGlassContainer.mm
@@ -20,7 +20,6 @@ using namespace facebook::react;
 
 @implementation ReactNativeLiquidGlassContainer {
   LiquidGlassContainer *_containerView;
-  Props::Shared _props;
   LayoutMetrics _layoutMetrics;
 }
 
@@ -56,9 +55,6 @@ using namespace facebook::react;
   if (oldViewProps.spacing != newViewProps.spacing) {
     [ReactNativeLiquidGlassContainerHelper updateLiquidGlassContainer:_containerView withSpacing:newViewProps.spacing];
   }
-
-  // Store the new props
-  _props = props;
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/ios/ReactNativeLiquidGlassView.mm
+++ b/ios/ReactNativeLiquidGlassView.mm
@@ -20,7 +20,6 @@ using namespace facebook::react;
 
 @implementation ReactNativeLiquidGlassView {
   LiquidGlassContainerView *_liquidGlassView;
-  Props::Shared _props;
   LayoutMetrics _layoutMetrics;
 }
 
@@ -242,9 +241,6 @@ using namespace facebook::react;
 
   // Apply all of the above in one effect rebuild.
   [_liquidGlassView endBatchUpdate];
-
-  // Store the new props
-  _props = props;
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/ios/ReactNativeProgressiveBlurView.mm
+++ b/ios/ReactNativeProgressiveBlurView.mm
@@ -20,7 +20,6 @@ using namespace facebook::react;
 
 @implementation ReactNativeProgressiveBlurView {
   ProgressiveBlurView *_progressiveBlurView;
-  Props::Shared _props;
 }
 
 + (UIColor *)colorFromString:(NSString *)colorString {
@@ -207,7 +206,6 @@ using namespace facebook::react;
     [ReactNativeProgressiveBlurViewHelper updateProgressiveBlurView:_progressiveBlurView withReducedTransparencyFallbackColor:fallbackColor];
   }
 
-  _props = props;
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/ReactNativeVibrancyView.mm
+++ b/ios/ReactNativeVibrancyView.mm
@@ -20,7 +20,6 @@ using namespace facebook::react;
 
 @implementation ReactNativeVibrancyView {
   VibrancyEffectView *_vibrancyView;
-  Props::Shared _props;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -63,7 +62,6 @@ using namespace facebook::react;
       [ReactNativeVibrancyViewHelper updateVibrancyView:_vibrancyView withBlurAmount:newViewProps.blurAmount];
   }
 
-  _props = props;
   [super updateProps:props oldProps:oldProps];
 }
 


### PR DESCRIPTION
React Native 0.87 started asserting that every `RCTViewComponentView` subclass keeps the inherited `_props` ivar populated. Mounting any of the five iOS views now throws an `NSInternalInconsistencyException` saying the view "must setup `_props` instance variable with a default value in the constructor". In our app the crash showed up as soon as a screen with a blur view mounted after we upgraded to 0.87.0.

The cause is that each view declares its own `Props::Shared _props;` ivar, which shadows the one inherited from `RCTViewComponentView`. All reads and writes in the subclass hit the local copy, so the base class ivar that React Native checks stays null.

The views also assign `_props = props` before calling `[super updateProps:oldProps:]`. Once the shadowed ivar is gone that line becomes harmful on its own: the superclass would diff `oldProps` against a `_props` that already holds the new value, see no change, and skip the standard `ViewProps` handling (opacity, transforms). The superclass already stores the new props at the end of its own `updateProps`, so the early assignment was redundant to begin with.

This PR removes the five shadowed ivars and the early assignments. Nothing else changes.

We've been running this exact diff as a pnpm patch on 6.0.0 in our app since the react-native 0.87 upgrade (new architecture). The blur views render as before and the crash is gone. Verified on the iOS simulator.
