### PR TITLE
fix(web): preserve server markup during blur hydration

### DIFF
--- a/src/BlurView.web.tsx
+++ b/src/BlurView.web.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, memo, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { BlurViewProps } from './BlurView';
-import { getBlurLayerStyle } from './webBlurUtils';
+import { getBlurLayerStyle, useBackdropFilterSupport } from './webBlurUtils';
 
 export type { BlurViewProps } from './BlurView';
 
@@ -37,13 +37,15 @@ const BlurViewComponent = forwardRef<BlurViewRef, BlurViewProps>(
     },
     ref
   ) => {
+    const hasBackdropFilter = useBackdropFilterSupport();
+
     const blurLayerStyle = useMemo(
       () => [
         StyleSheet.absoluteFill,
         styles.layer,
-        getBlurLayerStyle(blurType, blurAmount),
+        getBlurLayerStyle(blurType, blurAmount, hasBackdropFilter),
       ],
-      [blurType, blurAmount]
+      [blurType, blurAmount, hasBackdropFilter]
     );
     const overlayLayerStyle = useMemo(
       () => [

--- a/src/ProgressiveBlurView.web.tsx
+++ b/src/ProgressiveBlurView.web.tsx
@@ -1,11 +1,11 @@
-import React, { forwardRef, memo, useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, memo, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { ProgressiveBlurViewProps } from './ProgressiveBlurView';
 import {
   BLUR_TYPE_TO_BACKGROUND,
   getProgressiveLayers,
   getProgressiveTintGradient,
-  supportsBackdropFilter,
+  useBackdropFilterSupport,
 } from './webBlurUtils';
 import type { WebBlurStyle } from './webBlurUtils';
 
@@ -51,13 +51,7 @@ const ProgressiveBlurViewComponent = forwardRef<
     },
     ref
   ) => {
-    // The ramp layers mount only after the first client render: server-side /
-    // static rendering reports no backdrop-filter support, so painting them
-    // during the initial render would change the child count mid-hydration.
-    const [canUseBackdropFilter, setCanUseBackdropFilter] = useState(false);
-    useEffect(() => {
-      setCanUseBackdropFilter(supportsBackdropFilter());
-    }, []);
+    const canUseBackdropFilter = useBackdropFilterSupport();
 
     const blurLayerStyles = useMemo(() => {
       if (!canUseBackdropFilter) return [];

--- a/src/webBlurUtils.ts
+++ b/src/webBlurUtils.ts
@@ -1,3 +1,4 @@
+import { useSyncExternalStore } from 'react';
 import type { ViewStyle } from 'react-native';
 import type { BlurType } from './ReactNativeBlurViewNativeComponent';
 import type { ProgressiveBlurDirection } from './ReactNativeProgressiveBlurViewNativeComponent';
@@ -84,7 +85,7 @@ let backdropFilterSupport: boolean | undefined;
  * Feature-detects CSS backdrop-filter. Safe to call during server-side /
  * static rendering (Expo `web.output: "static"` renders in Node, where the
  * CSS API is absent) — it simply reports false there, leaving the tint-only
- * fallback styles. Memoized after the first call.
+ * fallback styles. Memoized once the CSS API is available.
  */
 export function supportsBackdropFilter(): boolean {
   if (backdropFilterSupport === undefined) {
@@ -93,12 +94,25 @@ export function supportsBackdropFilter(): boolean {
         CSS?: { supports?: (property: string, value: string) => boolean };
       }
     ).CSS;
+    if (typeof css?.supports !== 'function') return false;
     backdropFilterSupport =
-      typeof css?.supports === 'function' &&
-      (css.supports('backdrop-filter', 'blur(1px)') ||
-        css.supports('-webkit-backdrop-filter', 'blur(1px)'));
+      css.supports('backdrop-filter', 'blur(1px)') ||
+      css.supports('-webkit-backdrop-filter', 'blur(1px)');
   }
   return backdropFilterSupport;
+}
+
+// Browser support does not change during a mounted component's lifetime.
+const subscribeToBackdropSupport = () => () => {};
+const serverBackdropSupport = () => false;
+
+/** Keep server/hydration markup identical without delaying client-only mounts. */
+export function useBackdropFilterSupport(): boolean {
+  return useSyncExternalStore(
+    subscribeToBackdropSupport,
+    supportsBackdropFilter,
+    serverBackdropSupport
+  );
 }
 
 /**
@@ -109,13 +123,14 @@ export function supportsBackdropFilter(): boolean {
  */
 export function getBlurLayerStyle(
   blurType: BlurType,
-  blurAmount: number
+  blurAmount: number,
+  hasBackdropFilter = supportsBackdropFilter()
 ): WebBlurStyle {
   const style: WebBlurStyle = {
     backgroundColor:
       BLUR_TYPE_TO_BACKGROUND[blurType] ?? BLUR_TYPE_TO_BACKGROUND.regular,
   };
-  if (supportsBackdropFilter()) {
+  if (hasBackdropFilter) {
     const radius = cssNumber(clamp(blurAmount, 0, 100) * WEB_BLUR_RADIUS_SCALE);
     const filter = `blur(${radius}px) saturate(180%)`;
     style.backdropFilter = filter;

--- a/website/src/content/docs/blur-view.mdx
+++ b/website/src/content/docs/blur-view.mdx
@@ -55,6 +55,7 @@ On react-native-web, `BlurView` renders a `backdrop-filter: blur() saturate(180%
 
 - `overlayColor` paints above the blur, below children, like on native.
 - In browsers without `backdrop-filter` (and during server-side rendering), only the tint remains — the same graceful degradation `expo-blur` uses.
+- During hydration, the initial client render uses the same tint-only markup as the server. Supported browsers then enable blur; client-only rendering can enable it immediately.
 - `blurRounds`, `reducedTransparencyFallbackColor`, and `ignoreSafeArea` are native-only no-ops.
 - A forwarded `ref` resolves to the root `View` (a DOM element) instead of a native view.
 


### PR DESCRIPTION
## Fix

Use a shared useSyncExternalStore snapshot for CSS backdrop-filter support. Server and hydration snapshots stay tint-only; client-only rendering can use support immediately. Do not permanently cache an absent server CSS API. ProgressiveBlurView reuses the same hook instead of effect-driven local state.

## Compatibility / breaking changes

No API/default change. Server-rendered content gains blur after hydration without a React hydration mismatch; unsupported browsers retain tint-only rendering.

## Verification

Actual React 19/react-native-web SSR + JSDOM hydration: baseline one hydration warning and no blur layer; fixed zero warnings and one blur layer. Server-side feature detection can recover when CSS becomes available.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web blur behavior across server rendering and hydration.
  * Blur effects now activate reliably when browser support is detected.
  * Added safer handling for browsers without CSS backdrop-filter support.

* **Documentation**
  * Clarified hydration behavior for web blur views, including differences between server-rendered and client-only content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->