### PR TITLE
fix(android): retain resolved per-corner blur radii

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurView.kt
@@ -396,18 +396,19 @@ class ReactNativeBlurView : BlurViewGroup {
       val bottomLeft = if (borderBottomLeftRadius >= 0) convertDpToPx(borderBottomLeftRadius) else baseRadius
       val bottomRight = if (borderBottomRightRadius >= 0) convertDpToPx(borderBottomRightRadius) else baseRadius
 
+      // QmBlurView's uniform setter resets all four individual radii.
+      super.setCornerRadius(baseRadius)
       super.setTopLeftCornerRadius(topLeft)
       super.setTopRightCornerRadius(topRight)
       super.setBottomLeftCornerRadius(bottomLeft)
       super.setBottomRightCornerRadius(bottomRight)
-      super.setCornerRadius(baseRadius)
 
       val isUniform = topLeft == topRight && topRight == bottomLeft && bottomLeft == bottomRight
 
       if (isUniform) {
         outlineProvider = object : ViewOutlineProvider() {
           override fun getOutline(view: View, outline: Outline?) {
-            outline?.setRoundRect(0, 0, view.width, view.height, baseRadius)
+            outline?.setRoundRect(0, 0, view.width, view.height, topLeft)
           }
         }
       } else {


### PR DESCRIPTION
## Fix

Set QmBlurView’s uniform radius before its individual radii, because the uniform setter overwrites all four. Use the resolved corner value for uniform outline clipping.

## Compatibility / breaking changes

No API changes. Previously overwritten individual border radii now take effect, including equal explicit radii without a base borderRadius.

## Verification

Verified setter behavior from the actual QmBlurView 1.3 bytecode; compiled extracted implementation checks cover uniform, equal explicit, mixed and unset radii. Full Kotlin/codegen compilation and app Android builds pass.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #136
