### PR TITLE
fix(types): expose and forward standard view props

### DIFF
--- a/src/BlurSwitch.tsx
+++ b/src/BlurSwitch.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback } from 'react';
 import { Platform, StyleSheet, Switch } from 'react-native';
-import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
+import type { ViewStyle, StyleProp, ColorValue, ViewProps } from 'react-native';
 import ReactNativeBlurSwitch from './ReactNativeBlurSwitchNativeComponent';
 
 type NativeBlurSwitchProps = React.ComponentProps<typeof ReactNativeBlurSwitch>;
@@ -13,7 +13,7 @@ export const toColorString = (
   return fallback;
 };
 
-export interface BlurSwitchProps {
+export interface BlurSwitchProps extends ViewProps {
   /**
    * @description The current value of the switch
    *

--- a/src/BlurView.tsx
+++ b/src/BlurView.tsx
@@ -1,11 +1,11 @@
 import React, { Children, forwardRef, memo, useMemo } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
-import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
+import type { ViewStyle, StyleProp, ColorValue, ViewProps } from 'react-native';
 import ReactNativeBlurView, {
   type BlurType,
 } from './ReactNativeBlurViewNativeComponent';
 
-export interface BlurViewProps {
+export interface BlurViewProps extends ViewProps {
   /**
    * @description The type of blur effect to apply
    *

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, memo, useMemo } from 'react';
 import { Platform } from 'react-native';
-import type { ViewStyle, StyleProp } from 'react-native';
+import type { ViewStyle, StyleProp, ViewProps } from 'react-native';
 import ReactNativeLiquidGlassView, {
   type GlassType,
 } from './ReactNativeLiquidGlassViewNativeComponent';
@@ -11,7 +11,7 @@ import { FALLBACK_BLUR_AMOUNT, getFallbackOverlayColor } from './colorUtils';
 // platform-neutral colorUtils module (shared with the web implementation).
 export { getFallbackOverlayColor };
 
-export interface LiquidGlassViewProps {
+export interface LiquidGlassViewProps extends ViewProps {
   /**
    * @description The type of glass effect to apply
    *
@@ -174,6 +174,7 @@ const LiquidGlassViewComponent = forwardRef<
           reducedTransparencyFallbackColor={reducedTransparencyFallbackColor}
           ignoreSafeArea={ignoreSafeArea}
           style={style}
+          {...props}
         >
           {children}
         </BlurView>

--- a/src/ProgressiveBlurView.tsx
+++ b/src/ProgressiveBlurView.tsx
@@ -1,12 +1,12 @@
 import React, { Children, forwardRef, memo, useMemo } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
-import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
+import type { ViewStyle, StyleProp, ColorValue, ViewProps } from 'react-native';
 import ReactNativeProgressiveBlurView, {
   type BlurType,
   type ProgressiveBlurDirection,
 } from './ReactNativeProgressiveBlurViewNativeComponent';
 
-export interface ProgressiveBlurViewProps {
+export interface ProgressiveBlurViewProps extends ViewProps {
   /**
    * @description The type of blur effect to apply
    *

--- a/src/VibrancyView.tsx
+++ b/src/VibrancyView.tsx
@@ -1,12 +1,12 @@
 import React, { forwardRef, memo } from 'react';
 import { Platform, StyleSheet } from 'react-native';
-import type { ViewStyle, StyleProp } from 'react-native';
+import type { ViewStyle, StyleProp, ViewProps } from 'react-native';
 import ReactNativeVibrancyView, {
   type BlurType,
 } from './ReactNativeVibrancyViewNativeComponent';
 import BlurView from './BlurView';
 
-export interface VibrancyViewProps {
+export interface VibrancyViewProps extends ViewProps {
   /**
    * @description The type of blur effect to apply
    *

--- a/website/src/content/docs/props-reference.mdx
+++ b/website/src/content/docs/props-reference.mdx
@@ -15,6 +15,8 @@ import { blurTypeValues, glassTypeValues, progressiveBlurDirectionValues } from 
 
 A single scannable page listing every component's props side by side. For usage examples and platform-specific notes, see each component's own page.
 
+All six wrappers also accept standard React Native `ViewProps`, including `testID`, `onLayout`, `pointerEvents`, and accessibility properties. These are forwarded on native, web, and fallback paths; the tables below list the component-specific props.
+
 > **Refs:** the five view components (`BlurView`, `ProgressiveBlurView`, `VibrancyView`, `LiquidGlassView`, `LiquidGlassContainer`) forward a `ref` to their underlying native view on the primary platform path. On web, refs resolve to the root `View` (a DOM element).
 >
 > **Deprecated:** the raw `ReactNative*` native components are deprecated and will be removed in a future major — use the wrappers documented here. See [Migration](/react-native-blur/docs/migration).


### PR DESCRIPTION
## Fix

Extend the five missing wrapper interfaces with ViewProps. Forward remaining props through the LiquidGlassView blur fallback so testID, onLayout and accessibility props are not silently dropped.

## Compatibility / breaking changes

Additive type compatibility; no required props or default changes. Fallback views now receive props already accepted on the primary native path. Ref behavior is unchanged.

## Verification

Actual TypeScript consumer usage: five baseline errors become zero. Actual wrapper rendering with native host doubles verifies props on iOS 25/26 and Android 32/33; two baseline fallback failures become zero.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #137
