### PR TITLE
fix(android): avoid recycled glass captures and hidden refreshes

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeLiquidGlassView.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeLiquidGlassView.kt
@@ -82,7 +82,7 @@ class ReactNativeLiquidGlassView(context: Context) : FrameLayout(context) {
   // backdrop glued to the content at full frame rate. updateGlassNode is a
   // cheap no-op when neither the offset, the capture, nor the effect changed.
   private val scrollTrackingListener = ViewTreeObserver.OnPreDrawListener {
-    if (isSupported) {
+    if (canRefreshBackdrop) {
       updateGlassNode()
     }
     true
@@ -100,7 +100,7 @@ class ReactNativeLiquidGlassView(context: Context) : FrameLayout(context) {
   private val backdropTicker = object : Runnable {
     override fun run() {
       refreshBackdrop()
-      postDelayed(this, BACKDROP_REFRESH_MS)
+      if (canRefreshBackdrop) postDelayed(this, BACKDROP_REFRESH_MS)
     }
   }
 
@@ -184,10 +184,13 @@ class ReactNativeLiquidGlassView(context: Context) : FrameLayout(context) {
   // only runs while the view can actually be seen: it stops when the view or
   // its window is hidden (backgrounded app, covered screen, GONE subtree) and
   // restarts when visibility returns.
+  private val canRefreshBackdrop: Boolean
+    get() = isSupported && isAttachedToWindow && isShown && windowVisibility == VISIBLE
+
   private fun restartTickerIfVisible() {
     if (!constructed) return
     removeCallbacks(backdropTicker)
-    if (isSupported && isAttachedToWindow && isShown && windowVisibility == VISIBLE) {
+    if (canRefreshBackdrop) {
       postDelayed(backdropTicker, BACKDROP_REFRESH_MS)
     }
   }
@@ -263,7 +266,6 @@ class ReactNativeLiquidGlassView(context: Context) : FrameLayout(context) {
     if (shaderFailed || width <= 0 || height <= 0) return false
     val node = glassNode ?: return false
     val source = captureSource ?: return false
-    val bitmap = SharedBackdropCapture.peek(source) ?: return false
 
     source.getLocationInWindow(sourceLocation)
     getLocationInWindow(ownLocation)
@@ -280,6 +282,8 @@ class ReactNativeLiquidGlassView(context: Context) : FrameLayout(context) {
       SharedBackdropCapture.acquire(source, CAPTURE_DOWNSAMPLE, BACKDROP_REFRESH_MS)
     }
 
+    // acquire can recycle and replace the bitmap when the capture root resizes.
+    val bitmap = SharedBackdropCapture.peek(source) ?: return false
     val generation = SharedBackdropCapture.generationOf(source)
     if (
       generation == appliedGeneration &&
@@ -315,7 +319,7 @@ class ReactNativeLiquidGlassView(context: Context) : FrameLayout(context) {
   }
 
   private fun refreshBackdrop() {
-    if (!isSupported || width <= 0 || height <= 0 || !isAttachedToWindow) return
+    if (!canRefreshBackdrop || width <= 0 || height <= 0) return
     val source = captureSource ?: return
     if (source.width <= 0 || source.height <= 0) return
     refreshBackdrop33(source)


### PR DESCRIPTION
## Fix

Read the shared bitmap after an acquire that can recycle it during a resize. Reuse one visibility predicate for pre-draw, refresh and ticker scheduling, including rechecking after a reentrant hide/detach.

## Compatibility / breaking changes

No cadence, downsampling, shader or API changes. Hidden/detached views no longer perform otherwise unnecessary capture work; resized roots use the current bitmap.

## Verification

Compiled extracted Kotlin/API doubles reproduce a stale recycled bitmap and five hidden/detached/reentrant refresh failures on baseline; all fixed cases pass. Full Android source/codegen compilation and app builds pass.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #138
