### PR TITLE
fix(android): restore unaccepted controlled switch toggles

### DIFF
--- a/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitchManager.kt
+++ b/android/src/main/java/com/sbaiahmed1/reactnativeblur/ReactNativeBlurSwitchManager.kt
@@ -45,6 +45,10 @@ class ReactNativeBlurSwitchManager : SimpleViewManager<ReactNativeBlurSwitch>(),
     view?.setValue(value)
   }
 
+  override fun setNativeValue(view: ReactNativeBlurSwitch?, value: Boolean) {
+    view?.setValue(value)
+  }
+
   @ReactProp(name = "blurAmount")
   override fun setBlurAmount(view: ReactNativeBlurSwitch?, blurAmount: Double) {
     view?.setBlurAmount(blurAmount.toFloat())

--- a/src/BlurSwitch.tsx
+++ b/src/BlurSwitch.tsx
@@ -1,7 +1,15 @@
-import React, { memo, useCallback } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Platform, StyleSheet, Switch } from 'react-native';
 import type { ViewStyle, StyleProp, ColorValue } from 'react-native';
-import ReactNativeBlurSwitch from './ReactNativeBlurSwitchNativeComponent';
+import ReactNativeBlurSwitch, {
+  Commands,
+} from './ReactNativeBlurSwitchNativeComponent';
 
 type NativeBlurSwitchProps = React.ComponentProps<typeof ReactNativeBlurSwitch>;
 
@@ -115,14 +123,25 @@ const BlurSwitchComponent: React.FC<BlurSwitchProps> = ({
   style,
   ...props
 }) => {
+  const nativeRef =
+    useRef<React.ComponentRef<typeof ReactNativeBlurSwitch>>(null);
+  // A new object records every native event, including repeated rejected toggles.
+  const [native, setNative] = useState<{ value: boolean } | null>(null);
   const handleNativeValueChange = useCallback<
     NonNullable<NativeBlurSwitchProps['onValueChange']>
   >(
     (event) => {
       onValueChange?.(event.nativeEvent.value);
+      setNative({ value: event.nativeEvent.value });
     },
     [onValueChange]
   );
+
+  useLayoutEffect(() => {
+    if (native != null && native.value !== value && nativeRef.current != null) {
+      Commands.setNativeValue(nativeRef.current, value);
+    }
+  }, [native, value]);
 
   if (Platform.OS === 'ios') {
     return (
@@ -140,6 +159,7 @@ const BlurSwitchComponent: React.FC<BlurSwitchProps> = ({
 
   return (
     <ReactNativeBlurSwitch
+      ref={nativeRef}
       style={[styles.switch, style]}
       value={value}
       onValueChange={handleNativeValueChange}

--- a/src/ReactNativeBlurSwitchNativeComponent.ts
+++ b/src/ReactNativeBlurSwitchNativeComponent.ts
@@ -1,5 +1,6 @@
-import { codegenNativeComponent } from 'react-native';
-import type { CodegenTypes, ViewProps } from 'react-native';
+import { codegenNativeComponent, codegenNativeCommands } from 'react-native';
+import type { CodegenTypes, HostComponent, ViewProps } from 'react-native';
+import type React from 'react';
 
 export interface ValueChangeEvent {
   value: boolean;
@@ -15,6 +16,17 @@ interface NativeProps extends ViewProps {
   disabled?: CodegenTypes.WithDefault<boolean, false>;
   onValueChange?: CodegenTypes.DirectEventHandler<Readonly<ValueChangeEvent>>;
 }
+
+interface NativeCommands {
+  setNativeValue: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>,
+    value: boolean
+  ) => void;
+}
+
+export const Commands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['setNativeValue'],
+});
 
 export default codegenNativeComponent<NativeProps>('ReactNativeBlurSwitch', {
   excludedPlatforms: ['iOS'],

--- a/website/src/content/docs/blur-switch.mdx
+++ b/website/src/content/docs/blur-switch.mdx
@@ -15,6 +15,8 @@ import { blurSwitchProps } from '../props-data/blur-switch';
 
 ## Basic usage
 
+`BlurSwitch` is controlled on every platform: update `value` from `onValueChange` to accept a toggle. Leaving `value` unchanged restores the supplied state.
+
 ```tsx
 import { BlurSwitch } from '@sbaiahmed1/react-native-blur';
 

--- a/website/src/content/docs/migration.mdx
+++ b/website/src/content/docs/migration.mdx
@@ -4,6 +4,11 @@ description: Upgrading from v3.x, and migrating from @react-native-community/blu
 order: 9
 ---
 
+## Controlled Android switches
+
+`BlurSwitch` now restores the supplied `value` when a native toggle is not accepted by the parent, matching React Native's built-in `Switch` on iOS and web. Android apps that previously relied on toggles changing the UI without updating `value` must now store the value and update it in `onValueChange`. Omitting `value` keeps the switch off.
+
+
 ## Breaking changes in v6.0.0
 
 ### New: native liquid glass on Android 13+

--- a/website/src/content/props-data/blur-switch.ts
+++ b/website/src/content/props-data/blur-switch.ts
@@ -1,7 +1,7 @@
 import type { PropRow } from './types';
 
 export const blurSwitchProps: PropRow[] = [
-  { name: 'value', type: 'boolean', default: 'false', description: 'The current value of the switch.' },
+  { name: 'value', type: 'boolean', default: 'false', description: 'The controlled value of the switch. Update it from onValueChange to accept a toggle; otherwise the supplied value is restored.' },
   {
     name: 'onValueChange',
     type: '(value: boolean) => void',


### PR DESCRIPTION
## Fix

Add a Fabric setNativeValue command and restore the supplied value when the parent does not accept a native toggle. Record each event, including repeated rejected toggles, and leave accepted updates alone.

## Compatibility / breaking changes

Behavior change: Android callers relying on an uncontrolled-looking switch must store value and update it in onValueChange. Omitting value keeps the switch off. This matches the existing iOS/web controlled Switch contract; public prop signatures are unchanged.

## Verification

Actual React wrapper with a native-state/command double: absent and ignored handlers fail on baseline and restore correctly after the fix; repeated rejected toggles restore each time, accepted toggles issue no reset command. Generated native command and Kotlin manager compile against RN 0.87.1.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switch state synchronization across platforms, restoring the controlled value when a toggle is not accepted by the parent component.

* **Documentation**
  * Clarified that `BlurSwitch` is controlled on every platform.
  * Documented the need to update `value` from `onValueChange` to accept user toggles.
  * Added migration guidance for Android applications using controlled switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->