### PR TITLE
fix(ios): honor Fabric child insertion indices

### DIFF
--- a/ios/ReactNativeBlurView.mm
+++ b/ios/ReactNativeBlurView.mm
@@ -242,7 +242,8 @@ using namespace facebook::react;
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  [_advancedBlurView addSubview:childComponentView];
+  // Index zero belongs to the internal effect view, below all React children.
+  [_advancedBlurView insertSubview:childComponentView atIndex:index + 1];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index

--- a/ios/ReactNativeProgressiveBlurView.mm
+++ b/ios/ReactNativeProgressiveBlurView.mm
@@ -243,7 +243,8 @@ using namespace facebook::react;
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  [_progressiveBlurView addSubview:childComponentView];
+  // Index zero belongs to the internal effect view, below all React children.
+  [_progressiveBlurView insertSubview:childComponentView atIndex:index + 1];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index


### PR DESCRIPTION
## Fix

Insert raw native BlurView and ProgressiveBlurView children at their requested React index while preserving the internal effect view at index zero.

## Compatibility / breaking changes

No API changes. Raw native components remain deprecated, but now honor insertion/reordering rather than always appending. Standard iOS wrappers generally hoist their children and are unaffected.

## Verification

Compiled actual mount methods and ran insertion/move sequences against real UIKit in the iOS Simulator. Both baseline ordering failures pass after the fix, with the internal effect layer preserved.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #140
