### PR TITLE
fix(podspec): use the published v-prefixed release tag

### DIFF
--- a/ReactNativeBlur.podspec
+++ b/ReactNativeBlur.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported }
-  s.source       = { :git => "https://github.com/sbaiahmed1/react-native-blur.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/sbaiahmed1/react-native-blur.git", :tag => "v#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.swift_version = '5.0'


### PR DESCRIPTION
## Fix

Match the podspec source tag to the v${version} release tag convention. The published v6.0.1 exists; 6.0.1 does not.

## Compatibility / breaking changes

No runtime or local-path React Native autolinking change. Direct CocoaPods source resolution uses the existing release tag.

## Verification

Inspected release configuration and remote tags; podspec syntax and local pod installation pass. Direct remote pod publication was not attempted.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #142
