### PR TITLE
fix(lint): ignore generated example build output

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,10 @@ export default defineConfig([
     ignores: [
       'node_modules/',
       'lib/',
+      'example/dist/',
+      'example/android/',
+      'example/ios/',
+      'example/.expo/',
       'website/'
     ],
   },


### PR DESCRIPTION
## Fix

Exclude Expo output and generated Android/iOS projects so lint keeps checking source after export/prebuild.

## Compatibility / breaking changes

Tooling only; no source directories or lint rules are disabled.

## Verification

Baseline lint spent over 90 seconds processing a generated minified bundle and was stopped. ESLint isPathIgnored checks confirm the four generated directories are excluded and source/example TSX remains included. Full lint then completes with the three existing warnings.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #144
