### PR TITLE
fix(website): reset copy feedback after repeated clicks

### DIFF
--- a/website/src/components/InstallSnippet.astro
+++ b/website/src/components/InstallSnippet.astro
@@ -20,12 +20,12 @@ const { command = 'npm install @sbaiahmed1/react-native-blur' } = Astro.props;
 <script>
   document.querySelectorAll<HTMLButtonElement>('button[data-copy-command]').forEach((button) => {
     const original = button.textContent;
-    let resetTimeout: ReturnType<typeof setTimeout>;
+    let resetTimeout: ReturnType<typeof setTimeout> | undefined;
     button.addEventListener('click', async () => {
       const text = button.dataset.copyCommand ?? '';
       try {
         await navigator.clipboard.writeText(text);
-        clearTimeout(resetTimeout);
+        if (resetTimeout !== undefined) clearTimeout(resetTimeout);
         button.textContent = 'Copied!';
         resetTimeout = setTimeout(() => {
           button.textContent = original;

--- a/website/src/components/InstallSnippet.astro
+++ b/website/src/components/InstallSnippet.astro
@@ -19,13 +19,15 @@ const { command = 'npm install @sbaiahmed1/react-native-blur' } = Astro.props;
 
 <script>
   document.querySelectorAll<HTMLButtonElement>('button[data-copy-command]').forEach((button) => {
+    const original = button.textContent;
+    let resetTimeout: ReturnType<typeof setTimeout>;
     button.addEventListener('click', async () => {
       const text = button.dataset.copyCommand ?? '';
       try {
         await navigator.clipboard.writeText(text);
-        const original = button.textContent;
+        clearTimeout(resetTimeout);
         button.textContent = 'Copied!';
-        setTimeout(() => {
+        resetTimeout = setTimeout(() => {
           button.textContent = original;
         }, 1500);
       } catch {


### PR DESCRIPTION
## Fix

Capture the stable button label once and replace the pending reset timer after each successful copy.

## Compatibility / breaking changes

Website only; repeated clicks no longer leave Copied! displayed permanently. Clipboard failure behavior is unchanged.

## Verification

Actual extracted Astro client script executed with JSDOM and deterministic timers: repeated clicks fail on baseline and pass after the fix; independent buttons and copied commands remain correct. Website build passes.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install snippet copy buttons for rapid repeated clicks.
  * Button text now resets reliably without overlapping timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->