### PR TITLE
fix(website): make demo playback user controlled

### DIFF
--- a/website/src/components/DemoVideo.astro
+++ b/website/src/components/DemoVideo.astro
@@ -14,8 +14,8 @@ const videoSrc = withBase(`/media/videos/${src}`);
 
 <figure class={`glass-panel overflow-hidden p-2 ${className}`}>
   <video
-    data-lazy-video
-    data-src={videoSrc}
+    src={videoSrc}
+    controls
     muted
     loop
     playsinline
@@ -25,28 +25,3 @@ const videoSrc = withBase(`/media/videos/${src}`);
   </video>
   {caption && <figcaption class="px-2 pb-1 pt-3 text-center text-sm text-white/60">{caption}</figcaption>}
 </figure>
-
-<script>
-  const videos = document.querySelectorAll<HTMLVideoElement>('video[data-lazy-video]');
-
-  const observer = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        if (!entry.isIntersecting) continue;
-        const video = entry.target as HTMLVideoElement;
-        const source = video.dataset.src;
-        if (source && !video.src) {
-          video.src = source;
-          video.load();
-          video.play().catch(() => {
-            /* autoplay can be blocked; user can still tap play controls if added later */
-          });
-        }
-        observer.unobserve(video);
-      }
-    },
-    { rootMargin: '200px' }
-  );
-
-  videos.forEach((video) => observer.observe(video));
-</script>


### PR DESCRIPTION
## Fix

Render the video source directly with native controls and preload=none. Remove automatic IntersectionObserver playback, so videos can be played and paused without JavaScript and do not force motion.

## Compatibility / breaking changes

Website behavior change: demos start on user request rather than autoplaying. Native playback controls remain available if scripts are unavailable; no library API changes.

## Verification

Inspected generated static HTML for real src, controls and preload=none. Source checks confirm no script-driven play call or autoplay attribute. Website builds all 11 pages. No exhaustive assistive-technology/browser matrix is claimed.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #146
