### PR TITLE
fix(example): use valid colors and stable animation values

### DIFF
--- a/example/app/(tabs)/settings.tsx
+++ b/example/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
 import { Text, StyleSheet, ImageBackground, ScrollView } from 'react-native';
 import { BlurView } from '@sbaiahmed1/react-native-blur';
 import { DEMO_IMAGES } from '@/constants/blur';
+import { version } from '../../../package.json';
 
 export default function SettingsScreen() {
   return (
@@ -17,7 +18,7 @@ export default function SettingsScreen() {
           <Text style={styles.sectionText}>
             React Native Blur with QmBlurView integration
           </Text>
-          <Text style={styles.sectionText}>Version: 1.0.0</Text>
+          <Text style={styles.sectionText}>Library version: {version}</Text>
         </BlurView>
 
         <BlurView blurType="regular" blurAmount={60} style={styles.section}>
@@ -35,7 +36,7 @@ export default function SettingsScreen() {
             Powered by QmBlurView - A high-performance Android blur library
           </Text>
           <Text style={styles.sectionText}>
-            Minimum SDK: Android 5.0 (API 21)
+            Library minimum SDK: Android 7.0 (API 24)
           </Text>
         </BlurView>
       </ScrollView>

--- a/example/src/components/liquid-glass-example.tsx
+++ b/example/src/components/liquid-glass-example.tsx
@@ -2,7 +2,7 @@ import {
   LiquidGlassView,
   LiquidGlassContainer,
 } from '@sbaiahmed1/react-native-blur';
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import {
   View,
   Text,
@@ -12,6 +12,7 @@ import {
   Image,
   StyleSheet,
   Animated,
+  useAnimatedValue,
 } from 'react-native';
 import { glassColors } from '@/constants/blur';
 
@@ -24,9 +25,11 @@ const LiquidGlassExample = ({
     'clear' | 'regular'
   >('clear');
   const [glassTintColor, setGlassTintColor] = useState('#007AFF');
+  const buttonBackgroundColor =
+    glassTintColor === 'clear' ? 'transparent' : glassTintColor + '40';
   const [glassOpacity, setGlassOpacity] = useState(0.8);
   const [containerSpacing, setContainerSpacing] = useState(20);
-  const translateX = useRef(new Animated.Value(0)).current;
+  const translateX = useAnimatedValue(0);
 
   const animateCirclesCloser = () => {
     Animated.sequence([
@@ -58,7 +61,7 @@ const LiquidGlassExample = ({
           glassTintColor={glassTintColor}
           glassOpacity={glassOpacity}
           style={[styles.liquidGlassCard, { borderRadius: 20 }]}
-          reducedTransparencyFallbackColor="rgba(255, 255, 255, 0.9)"
+          reducedTransparencyFallbackColor="#FFFFFFE6"
         >
           <Text style={styles.liquidGlassTitle}>🌊 Liquid Glass</Text>
           <Text style={styles.liquidGlassInfo}>Type: {selectedGlassType}</Text>
@@ -71,7 +74,7 @@ const LiquidGlassExample = ({
           <TouchableOpacity
             style={[
               styles.glassButton,
-              { backgroundColor: glassTintColor + '40' },
+              { backgroundColor: buttonBackgroundColor },
             ]}
             onPress={cycleBackground}
           >


### PR DESCRIPTION
## Fix

Use transparent for the clear button background and #FFFFFFE6 for the native fallback. Use React Native useAnimatedValue to avoid allocating an unused animation value on every render. Read the library version from package metadata and correct its minimum Android SDK label.

## Compatibility / breaking changes

Example only; native fallback becomes the intended mostly opaque white rather than clear. Animation behavior and public library API are unchanged.

## Verification

Actual example component rendered with React/native host doubles: selecting Clear changes an invalid color to a valid transparent RN color; fallback uses supported RGBA hex. A state rerender allocates one Animated.Value instead of two. React Doctor’s compiler/refs error is resolved; typecheck and lint pass.

Combined review branch: 40 existing Jest tests across four suites, TypeScript, ESLint (three pre-existing inline-style warnings), Bob builds, web-entry graph validation and whitespace checks passed. No checked-in tests/specs were added or changed. Consumer integration passed both products’ Android Debug and iOS Simulator Debug builds, four production Metro bundles, 13 web targets and four browser-extension targets. The upstream example built for Android and iOS, exported for web, and its iOS home screen was launched and visually inspected. Physical-device, signed-release and Android runtime testing were not performed.

Closes #147
