### PR TITLE
[LOW] fix(ci): scope Pages permissions to deploy job

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -33,6 +31,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Executive Summary

This change applies least-privilege permissions to the GitHub Pages workflow. It removes `pages: write` and `id-token: write` from the website build job and grants them only to the deployment job that requires them.

Severity: **LOW**. This is preventive CI hardening; no exploitation is known or claimed.

## Background

GitHub recommends granting `pages: write` and `id-token: write` to the Pages deployment job. The OIDC permission allows a job to request an OIDC token. See [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages) and [GitHub OIDC security guidance](https://docs.github.com/en/actions/reference/security/oidc).

## Vulnerability Details

The workflow previously declared `contents: read`, `pages: write`, and `id-token: write` at workflow scope. Consequently, both `build` and `deploy` inherited all three permissions.

The `build` job checks out the repository and runs the pinned Astro action, which installs dependencies and builds the website. It does not need permission to write Pages deployments or request an OIDC token.

## Exploitability Analysis

The workflow runs only for pushes to `main` affecting configured paths and for manual dispatches, which limits exposure. The referenced actions are also pinned.

However, unnecessary write and OIDC capabilities increase the impact of a compromised build action or dependency. Restricting these permissions removes that avoidable capability from the broader build surface.

## Proof of Concept

Inspection of the workflow permission hierarchy shows that workflow-level permissions are inherited by every job without an override. Therefore, the build job receives `pages: write` and `id-token: write` despite never using either capability.

No active exploitation was attempted or observed.

## Remediation

The patch retains only `contents: read` at workflow scope and grants `pages: write` and `id-token: write` specifically to `deploy`. The workflow triggers and build/deployment behavior are unchanged.

Verification completed: workflow YAML parsed; 4 test suites and 40 tests passed; type checking passed; lint passed with 3 pre-existing warnings; package preparation/build passed; and `git diff --check` passed.

No regression test file was added because this is declarative workflow permission scoping; the existing repository checks cover non-regression.

## Summary

This change reduces the website build job's token privileges without changing functionality. Only the Pages deployment job retains the write and OIDC permissions required for deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated website deployment permissions to follow least-privilege access.
  * Build operations retain read-only permissions, while deployment receives only the permissions required to publish the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->